### PR TITLE
Fixed incorrect location after numeric literals starting with '.'

### DIFF
--- a/src/cobalt/tokenizer.cpp
+++ b/src/cobalt/tokenizer.cpp
@@ -1044,6 +1044,7 @@ std::vector<token> cobalt::tokenize(std::string_view code, location loc, flags_t
             if (c2 >= '0' && c2 <= '9') {
               --it;
               out.push_back({loc, parse_num(it, end, {loc, flags.onerror}, step)});
+              --loc.col;
             }
             else out.push_back({loc, "."});
             topb = true;


### PR DESCRIPTION
Numeric literals like `.5` would count an extra column. For example, the code `.5 x` would give the tokens:
```
file:1:1: <.5 as double>
file:1:5: x
```