### PR TITLE
Move default_macros definition to its own file

### DIFF
--- a/src/cobalt/macros.cpp
+++ b/src/cobalt/macros.cpp
@@ -1,4 +1,5 @@
 #include "cobalt/tokenizer.hpp"
+#include "cobalt/version.hpp"
 #include <llvm/Support/MemoryBuffer.h>
 #include <llvm/Support/FileSystem.h>
 using namespace cobalt;
@@ -131,6 +132,7 @@ macro_map cobalt::default_macros {
   })
   DEF_PP(region, {(void)code; return "";})
   DEF_PP(endregion, {(void)code; return "";})
+  DEF_PP(version, {(void)code; return COBALT_VERSION;})
   DEF_PP(print, {llvm::outs() << code; return "";})
   DEF_PP(eprint, {llvm::errs() << code; return "";})
   DEF_PP(println, {llvm::outs() << code << '\n'; return "";})

--- a/src/cobalt/tokenizer.cpp
+++ b/src/cobalt/tokenizer.cpp
@@ -557,11 +557,7 @@ std::vector<token> cobalt::tokenize(std::string_view code, location loc, flags_t
           }
           else {
             auto it = macros.find(sstring::get(macro_id));
-            if (it == macros.end()) {
-              out.push_back({start_l, "@"});
-              ++start_l.col;
-              out.push_back({start_l, std::string(macro_id)});
-            }
+            if (it == macros.end()) out.push_back({start_l, "@" + std::string(macro_id)});
             else {
               auto f2 = flags;
               f2.update_location = false;


### PR DESCRIPTION
Since changes will be made to both the tokenizer and the predefined macros, moving them to separate files will reduce the rebuild time.