### PR TITLE
Fixed various compile errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,11 +15,11 @@ add_link_options(${LINK_DIR} ${LLVM_LIB})
 include_directories(include)
 add_library(cobalt
   include/cobalt.hpp
-    include/cobalt/ast.hpp include/cobalt/ast/ast.hpp include/cobalt/ast/flow.hpp include/cobalt/ast/meta.hpp include/cobalt/ast/vars.hpp
+    include/cobalt/ast.hpp include/cobalt/ast/ast.hpp include/cobalt/ast/flow.hpp include/cobalt/ast/funcs.hpp include/cobalt/ast/meta.hpp include/cobalt/ast/vars.hpp
     include/cobalt/support/location.hpp include/cobalt/support/sstring.hpp include/cobalt/support/functions.hpp include/cobalt/support/token.hpp
     include/cobalt/types/types.hpp include/cobalt/types/numeric.hpp include/cobalt/types/pointers.hpp include/cobalt/types/structurals.hpp
     include/cobalt/context.hpp include/cobalt/varmap.hpp include/cobalt/typed_value.hpp
-  src/cobalt/tokenizer.cpp src/cobalt/macros.cpp src/cobalt/parser.cpp)
+  src/cobalt/tokenizer.cpp src/cobalt/macros.cpp src/cobalt/parser.cpp src/cobalt/codegen.cpp)
 add_executable(co src/co/main.cpp)
 target_link_libraries(co cobalt)
 

--- a/include/cobalt/ast.hpp
+++ b/include/cobalt/ast.hpp
@@ -1,4 +1,8 @@
 #ifndef COBALT_AST_HPP
 #define COBALT_AST_HPP
 #include "cobalt/ast/ast.hpp"
+#include "cobalt/ast/flow.hpp"
+#include "cobalt/ast/funcs.hpp"
+#include "cobalt/ast/meta.hpp"
+#include "cobalt/ast/vars.hpp"
 #endif

--- a/include/cobalt/ast/flow.hpp
+++ b/include/cobalt/ast/flow.hpp
@@ -6,22 +6,26 @@ namespace cobalt::ast {
     std::vector<AST> insts;
     block_ast(location loc, std::vector<AST>&& insts) : ast_base(loc), CO_INIT(insts) {}
     bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<block_ast const*>(other)) return insts == ptr->insts; else return false;}
+  private: typed_value codegen_impl(compile_context& ctx) const override;
   };
   struct if_ast : ast_base {
     AST cond, if_true, if_false;
     if_ast(location loc, AST&& cond, AST&& if_true, AST&& if_false = nullptr) : ast_base(loc), CO_INIT(cond), CO_INIT(if_true), CO_INIT(if_false) {}
     bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<if_ast const*>(other)) return cond == ptr->cond && if_true == ptr->if_true && if_false == ptr->if_false; else return false;}
+  private: typed_value codegen_impl(compile_context& ctx) const override;
   };
   struct while_ast : ast_base {
     AST cond, body;
     while_ast(location loc, AST&& cond, AST&& body) : ast_base(loc), CO_INIT(cond), CO_INIT(body) {}
     bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<while_ast const*>(other)) return cond == ptr->cond && body == ptr->body; else return false;}
+  private: typed_value codegen_impl(compile_context& ctx) const override;
   };
   struct for_ast : ast_base {
     AST cond, body;
     sstring elem_name;
-    while_ast(location loc, AST&& cond, AST&& body) : ast_base(loc), CO_INIT(cond), CO_INIT(body) {}
+    for_ast(location loc, sstring elem_name, AST&& cond, AST&& body) : ast_base(loc), CO_INIT(cond), CO_INIT(body), elem_name(elem_name) {}
     bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<while_ast const*>(other)) return cond == ptr->cond && body == ptr->body; else return false;}
+  private: typed_value codegen_impl(compile_context& ctx) const override;
   };
 }
 #endif

--- a/include/cobalt/ast/funcs.hpp
+++ b/include/cobalt/ast/funcs.hpp
@@ -1,0 +1,25 @@
+#ifndef COBALT_AST_FUNCS_HPP
+#define COBALT_AST_FUNCS_HPP
+#include "cobalt/ast/ast.hpp"
+#include "cobalt/types/types.hpp"
+namespace cobalt::ast {
+  struct binop_ast : ast_base {
+    sstring op;
+    AST lhs, rhs;
+    binop_ast(location loc, sstring op, AST&& lhs, AST&& rhs) : ast_base(loc), op(op), CO_INIT(lhs), CO_INIT(rhs) {}
+    bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<binop_ast const*>(other) return op == ptr->op && lhs == ptr->lhs && rhs == ptr->rhs; else return false;}
+  };
+  struct call_ast {
+    sstring name;
+    std::vector<AST> args;
+    binop_ast(location loc, sstring name, std::vector<AST>&& args) : ast_base(loc), name(name), CO_INIT(args) {}
+    bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<call_ast const*>(other) return op == ptr->op && args == ptr->args; else return false;}
+  };
+  struct fndef_ast {
+    sstring name;
+    std::vector<type_ptr> args;
+    fndef_ast(location loc, sstring name, std::vector<type_ptr>&& args) : ast_base(loc), name(name), CO_INIT(args) {}
+    bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<call_ast const*>(other) return op == ptr->op && args == ptr->args; else return false;}
+  };
+}
+#endif

--- a/include/cobalt/ast/funcs.hpp
+++ b/include/cobalt/ast/funcs.hpp
@@ -7,19 +7,29 @@ namespace cobalt::ast {
     sstring op;
     AST lhs, rhs;
     binop_ast(location loc, sstring op, AST&& lhs, AST&& rhs) : ast_base(loc), op(op), CO_INIT(lhs), CO_INIT(rhs) {}
-    bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<binop_ast const*>(other) return op == ptr->op && lhs == ptr->lhs && rhs == ptr->rhs; else return false;}
+    bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<binop_ast const*>(other)) return op == ptr->op && lhs == ptr->lhs && rhs == ptr->rhs; else return false;}
+  private: typed_value codegen_impl(compile_context& ctx) const override;
   };
-  struct call_ast {
+  struct unop_ast : ast_base {
+    sstring op;
+    AST val;
+    unop_ast(location loc, sstring op, AST&& val) : ast_base(loc), op(op), CO_INIT(val) {}
+    bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<unop_ast const*>(other)) return op == ptr->op && val == ptr->val; else return false;}
+  private: typed_value codegen_impl(compile_context& ctx) const override;
+  };
+  struct call_ast : ast_base {
     sstring name;
     std::vector<AST> args;
-    binop_ast(location loc, sstring name, std::vector<AST>&& args) : ast_base(loc), name(name), CO_INIT(args) {}
-    bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<call_ast const*>(other) return op == ptr->op && args == ptr->args; else return false;}
+    call_ast(location loc, sstring name, std::vector<AST>&& args) : ast_base(loc), name(name), CO_INIT(args) {}
+    bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<call_ast const*>(other)) return name == ptr->name && args == ptr->args; else return false;}
+  private: typed_value codegen_impl(compile_context& ctx) const override;
   };
-  struct fndef_ast {
+  struct fndef_ast : ast_base {
     sstring name;
     std::vector<type_ptr> args;
     fndef_ast(location loc, sstring name, std::vector<type_ptr>&& args) : ast_base(loc), name(name), CO_INIT(args) {}
-    bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<call_ast const*>(other) return op == ptr->op && args == ptr->args; else return false;}
+    bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<fndef_ast const*>(other)) return name == ptr->name && args == ptr->args; else return false;}
+  private: typed_value codegen_impl(compile_context& ctx) const override;
   };
 }
 #endif

--- a/include/cobalt/ast/vars.hpp
+++ b/include/cobalt/ast/vars.hpp
@@ -4,13 +4,24 @@
 namespace cobalt {
   namespace ast {
     struct vardef_ast : ast_base {
-      typed_value codegen(compile_context& ctx) const override;
+      sstring name;
+      AST val;
+      vardef_ast(location loc, sstring name, AST&& val) : ast_base(loc), name(name), CO_INIT(val) {}
+      bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<vardef_ast const*>(other)) return name == ptr->name && val == ptr->val; else return false;}
+    private: typed_value codegen_impl(compile_context& ctx) const override;
     };
     struct mutdef_ast : ast_base {
-      typed_value codegen(compile_context& ctx) const override;
+      sstring name;
+      AST val;
+      mutdef_ast(location loc, sstring name, AST&& val) : ast_base(loc), name(name), CO_INIT(val) {}
+      bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<mutdef_ast const*>(other)) return name == ptr->name && val == ptr->val; else return false;}
+    private: typed_value codegen_impl(compile_context& ctx) const override;
     };
     struct varget_ast : ast_base {
-      typed_value codegen(compile_context& ctx) const override;
+      sstring name;
+      varget_ast(location loc, sstring name) : ast_base(loc), name(name) {}
+      bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<varget_ast const*>(other)) return name == ptr->name; else return false;}
+      private: typed_value codegen_impl(compile_context& ctx) const override;
     };
   }
 }

--- a/include/cobalt/typed_value.hpp
+++ b/include/cobalt/typed_value.hpp
@@ -7,5 +7,6 @@ namespace cobalt {
     llvm::Value* value;
     types::type_base const* type;
   };
+  inline typed_value nullval {nullptr, nullptr};
 }
 #endif

--- a/include/cobalt/types/types.hpp
+++ b/include/cobalt/types/types.hpp
@@ -18,7 +18,7 @@ namespace cobalt {
       virtual std::size_t align() const = 0;
       virtual llvm::Type* llvm_type(location loc, compile_context& ctx) const = 0;
     };
-    inline type_base::~type_base() {(void);}
+    inline type_base::~type_base() {}
   }
   using type_ptr = types::type_base const*;
 }

--- a/src/cobalt/codegen.cpp
+++ b/src/cobalt/codegen.cpp
@@ -1,0 +1,18 @@
+#include "cobalt/ast.hpp"
+using namespace cobalt;
+// flow.hpp
+typed_value cobalt::ast::block_ast::codegen_impl(compile_context& ctx) const {(void)ctx; return nullval;}
+typed_value cobalt::ast::if_ast::codegen_impl(compile_context& ctx) const {(void)ctx; return nullval;}
+typed_value cobalt::ast::while_ast::codegen_impl(compile_context& ctx) const {(void)ctx; return nullval;}
+typed_value cobalt::ast::for_ast::codegen_impl(compile_context& ctx) const {(void)ctx; return nullval;}
+// funcs.hpp
+typed_value cobalt::ast::binop_ast::codegen_impl(compile_context& ctx) const {(void)ctx; return nullval;}
+typed_value cobalt::ast::call_ast::codegen_impl(compile_context& ctx) const {(void)ctx; return nullval;}
+typed_value cobalt::ast::fndef_ast::codegen_impl(compile_context& ctx) const {(void)ctx; return nullval;}
+// meta.hpp
+typed_value cobalt::ast::llvm_ast::codegen_impl(compile_context& ctx) const {(void)ctx; return nullval;}
+typed_value cobalt::ast::asm_ast::codegen_impl(compile_context& ctx) const {(void)ctx; return nullval;}
+// vars.hpp
+typed_value cobalt::ast::vardef_ast::codegen_impl(compile_context& ctx) const {(void)ctx; return nullval;}
+typed_value cobalt::ast::mutdef_ast::codegen_impl(compile_context& ctx) const {(void)ctx; return nullval;}
+typed_value cobalt::ast::varget_ast::codegen_impl(compile_context& ctx) const {(void)ctx; return nullval;}


### PR DESCRIPTION
This PR makes all AST node types concrete, standardizes the constructor types, and fixes various compile-time errors.
Constructors for `cobalt::ast::llvm_ast` and `cobalt::ast::asm_ast` have had their constructors modified to have their location as the first parameter and all AST node types have a constructor and `codegen_impl` implementation.