### PR TITLE
Added support for pretty-printing of ASTs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ add_library(cobalt
     include/cobalt/support/location.hpp include/cobalt/support/sstring.hpp include/cobalt/support/functions.hpp include/cobalt/support/token.hpp
     include/cobalt/types/types.hpp include/cobalt/types/numeric.hpp include/cobalt/types/pointers.hpp include/cobalt/types/structurals.hpp
     include/cobalt/context.hpp include/cobalt/varmap.hpp include/cobalt/typed_value.hpp
-  src/cobalt/tokenizer.cpp src/cobalt/macros.cpp src/cobalt/parser.cpp src/cobalt/codegen.cpp)
+  src/cobalt/tokenizer.cpp src/cobalt/macros.cpp src/cobalt/parser.cpp src/cobalt/print-ast.cpp src/cobalt/codegen.cpp)
 add_executable(co src/co/main.cpp)
 target_link_libraries(co cobalt)
 

--- a/include/cobalt/ast/ast.hpp
+++ b/include/cobalt/ast/ast.hpp
@@ -7,6 +7,7 @@
 namespace cobalt {
   struct compile_context;
   extern compile_context global;
+  class AST;
   namespace ast {
     struct ast_base {
       location loc;
@@ -15,14 +16,22 @@ namespace cobalt {
       virtual ~ast_base() noexcept = 0;
       virtual bool eq(ast_base const* other) const = 0;
       typed_value codegen(compile_context& ctx = global) const;
+      void print(llvm::raw_ostream& os) const {print_impl(os, "");}
     private:
       virtual typed_value codegen_impl(compile_context& ctx) const = 0;
+      virtual void print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const = 0;
+      friend class ::cobalt::AST;
+    protected:
+      void print_self(llvm::raw_ostream& os, llvm::Twine name) const;
+      void print_node(llvm::raw_ostream& os, llvm::Twine prefix, AST const& ast, bool last) const;
     };
     inline ast_base::~ast_base() noexcept {}
     inline typed_value ast_base::codegen(compile_context& ctx) const {return codegen_impl(ctx);}
   }
   class AST {
+    friend class ast::ast_base;
     ast::ast_base* ptr;
+    void print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {ptr->print_impl(os, prefix);}
   public:
     AST(std::nullptr_t) noexcept : ptr(nullptr) {}
     AST(ast::ast_base* ptr) noexcept : ptr(ptr) {}
@@ -42,6 +51,10 @@ namespace cobalt {
     inline typed_value codegen(compile_context& ctx = global) const {return ptr->codegen(ctx);}
     inline typed_value operator()(compile_context& ctx = global) const {return ptr->codegen(ctx);}
     bool operator==(AST const& other) const {return ptr->eq(other.ptr);}
+    explicit operator bool() const noexcept {return (bool)ptr;}
+    ast::ast_base* get() const noexcept {return ptr;}
+    template <class T> T* cast() const {return ptr ? static_cast<T*>(ptr) : (T*)ptr;}
+    template <class T> T* dyn_cast() const {return ptr ? dynamic_cast<T*>(ptr) : (T*)ptr;}
     template <class T, class... As> static AST create(As&&... args) {return new T(std::forward<As>(args)...);}
     template <class T, class... As> static AST create_nothrow(As&&... args) noexcept {
       ast::ast_base* ptr;

--- a/include/cobalt/ast/flow.hpp
+++ b/include/cobalt/ast/flow.hpp
@@ -6,26 +6,34 @@ namespace cobalt::ast {
     std::vector<AST> insts;
     block_ast(location loc, std::vector<AST>&& insts) : ast_base(loc), CO_INIT(insts) {}
     bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<block_ast const*>(other)) return insts == ptr->insts; else return false;}
-  private: typed_value codegen_impl(compile_context& ctx) const override;
+  private: 
+    typed_value codegen_impl(compile_context& ctx) const override;
+    void print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const override;
   };
   struct if_ast : ast_base {
     AST cond, if_true, if_false;
     if_ast(location loc, AST&& cond, AST&& if_true, AST&& if_false = nullptr) : ast_base(loc), CO_INIT(cond), CO_INIT(if_true), CO_INIT(if_false) {}
     bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<if_ast const*>(other)) return cond == ptr->cond && if_true == ptr->if_true && if_false == ptr->if_false; else return false;}
-  private: typed_value codegen_impl(compile_context& ctx) const override;
+  private: 
+    typed_value codegen_impl(compile_context& ctx) const override;
+    void print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const override;
   };
   struct while_ast : ast_base {
     AST cond, body;
     while_ast(location loc, AST&& cond, AST&& body) : ast_base(loc), CO_INIT(cond), CO_INIT(body) {}
     bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<while_ast const*>(other)) return cond == ptr->cond && body == ptr->body; else return false;}
-  private: typed_value codegen_impl(compile_context& ctx) const override;
+  private: 
+    typed_value codegen_impl(compile_context& ctx) const override;
+    void print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const override;
   };
   struct for_ast : ast_base {
     AST cond, body;
     sstring elem_name;
     for_ast(location loc, sstring elem_name, AST&& cond, AST&& body) : ast_base(loc), CO_INIT(cond), CO_INIT(body), elem_name(elem_name) {}
     bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<while_ast const*>(other)) return cond == ptr->cond && body == ptr->body; else return false;}
-  private: typed_value codegen_impl(compile_context& ctx) const override;
+  private: 
+    typed_value codegen_impl(compile_context& ctx) const override;
+    void print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const override;
   };
 }
 #endif

--- a/include/cobalt/ast/funcs.hpp
+++ b/include/cobalt/ast/funcs.hpp
@@ -8,28 +8,36 @@ namespace cobalt::ast {
     AST lhs, rhs;
     binop_ast(location loc, sstring op, AST&& lhs, AST&& rhs) : ast_base(loc), op(op), CO_INIT(lhs), CO_INIT(rhs) {}
     bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<binop_ast const*>(other)) return op == ptr->op && lhs == ptr->lhs && rhs == ptr->rhs; else return false;}
-  private: typed_value codegen_impl(compile_context& ctx) const override;
+  private: 
+    typed_value codegen_impl(compile_context& ctx) const override;
+    void print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const override;
   };
   struct unop_ast : ast_base {
     sstring op;
     AST val;
     unop_ast(location loc, sstring op, AST&& val) : ast_base(loc), op(op), CO_INIT(val) {}
     bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<unop_ast const*>(other)) return op == ptr->op && val == ptr->val; else return false;}
-  private: typed_value codegen_impl(compile_context& ctx) const override;
+  private: 
+    typed_value codegen_impl(compile_context& ctx) const override;
+    void print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const override;
   };
   struct call_ast : ast_base {
     sstring name;
     std::vector<AST> args;
     call_ast(location loc, sstring name, std::vector<AST>&& args) : ast_base(loc), name(name), CO_INIT(args) {}
     bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<call_ast const*>(other)) return name == ptr->name && args == ptr->args; else return false;}
-  private: typed_value codegen_impl(compile_context& ctx) const override;
+  private: 
+    typed_value codegen_impl(compile_context& ctx) const override;
+    void print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const override;
   };
   struct fndef_ast : ast_base {
     sstring name;
     std::vector<type_ptr> args;
     fndef_ast(location loc, sstring name, std::vector<type_ptr>&& args) : ast_base(loc), name(name), CO_INIT(args) {}
     bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<fndef_ast const*>(other)) return name == ptr->name && args == ptr->args; else return false;}
-  private: typed_value codegen_impl(compile_context& ctx) const override;
+  private: 
+    typed_value codegen_impl(compile_context& ctx) const override;
+    void print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const override;
   };
 }
 #endif

--- a/include/cobalt/ast/meta.hpp
+++ b/include/cobalt/ast/meta.hpp
@@ -5,12 +5,16 @@ namespace cobalt::ast {
   struct llvm_ast : ast_base {
     std::string code;
     llvm_ast(location loc, std::string&& code) : ast_base(loc), code(std::move(code)) {}
-    private: typed_value codegen_impl(compile_context& ctx) const override;
+    private: 
+    typed_value codegen_impl(compile_context& ctx) const override;
+    void print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const override;
   };
   struct asm_ast : ast_base {
     std::string code;
     asm_ast(location loc, std::string&& code) : ast_base(loc), code(std::move(code)) {}
-    private: typed_value codegen_impl(compile_context& ctx) const override;
+    private: 
+    typed_value codegen_impl(compile_context& ctx) const override;
+    void print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const override;
   };
 }
 #endif

--- a/include/cobalt/ast/vars.hpp
+++ b/include/cobalt/ast/vars.hpp
@@ -8,20 +8,26 @@ namespace cobalt {
       AST val;
       vardef_ast(location loc, sstring name, AST&& val) : ast_base(loc), name(name), CO_INIT(val) {}
       bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<vardef_ast const*>(other)) return name == ptr->name && val == ptr->val; else return false;}
-    private: typed_value codegen_impl(compile_context& ctx) const override;
+    private: 
+    typed_value codegen_impl(compile_context& ctx) const override;
+    void print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const override;
     };
     struct mutdef_ast : ast_base {
       sstring name;
       AST val;
       mutdef_ast(location loc, sstring name, AST&& val) : ast_base(loc), name(name), CO_INIT(val) {}
       bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<mutdef_ast const*>(other)) return name == ptr->name && val == ptr->val; else return false;}
-    private: typed_value codegen_impl(compile_context& ctx) const override;
+    private: 
+    typed_value codegen_impl(compile_context& ctx) const override;
+    void print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const override;
     };
     struct varget_ast : ast_base {
       sstring name;
       varget_ast(location loc, sstring name) : ast_base(loc), name(name) {}
       bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<varget_ast const*>(other)) return name == ptr->name; else return false;}
-      private: typed_value codegen_impl(compile_context& ctx) const override;
+      private: 
+    typed_value codegen_impl(compile_context& ctx) const override;
+    void print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const override;
     };
   }
 }

--- a/src/cobalt/print-ast.cpp
+++ b/src/cobalt/print-ast.cpp
@@ -1,0 +1,84 @@
+#include "cobalt/ast.hpp"
+using namespace cobalt;
+// ast.hpp
+void cobalt::ast::ast_base::print_self(llvm::raw_ostream& os, llvm::Twine name) const {os << name + "\n";}
+void cobalt::ast::ast_base::print_node(llvm::raw_ostream& os, llvm::Twine prefix, AST const& ast, bool last) const {
+  os << prefix + (last ? "└── ": "├── ");
+  ast.print_impl(os, prefix + (last ? "    " : "|   "));
+}
+// flow.hpp
+void cobalt::ast::block_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {
+  print_self(os, "block");
+  if (insts.empty()) return;
+  auto last = &insts.back();
+  for (auto const& ast : insts) print_node(os, prefix, ast, &ast == last);
+}
+void cobalt::ast::if_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {
+  if (if_false) {
+    print_self(os, "if/else");
+    print_node(os, prefix, cond, false);
+    print_node(os, prefix, if_true, false);
+    print_node(os, prefix, if_false, true);
+  }
+  else {
+    print_self(os, "if");
+    print_node(os, prefix, cond, false);
+    print_node(os, prefix, if_true, true);
+  }
+}
+void cobalt::ast::while_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {
+  print_self(os, "while");
+  print_node(os, prefix, cond, false);
+  print_node(os, prefix, body, true);
+}
+void cobalt::ast::for_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {
+  print_self(os, llvm::Twine("for: ") + elem_name);
+  print_node(os, prefix, cond, false);
+  print_node(os, prefix, body, true);
+}
+// funcs.hpp
+void cobalt::ast::binop_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {
+  print_self(os, llvm::Twine("op: ") + op);
+  print_node(os, prefix, lhs, false);
+  print_node(os, prefix, rhs, true);
+}
+void cobalt::ast::unop_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {
+  print_self(os, llvm::Twine("op: ") + op);
+  print_node(os, prefix, val, true);
+}
+void cobalt::ast::call_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {
+  print_self(os, llvm::Twine("call: ") + name);
+  if (args.empty()) return;
+  auto last = &args.back();
+  for (auto const& ast : args) print_node(os, prefix, ast, &ast == last);
+}
+void cobalt::ast::fndef_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {
+  os << llvm::Twine("fndef: ") + name + ", args: ";
+  auto last = &args.back();
+  for (auto const& type : args) os << (&type == last ? llvm::Twine(type->name()) + "\n" : llvm::Twine(type->name()) + ", ");
+}
+// meta.hpp
+void cobalt::ast::llvm_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {
+  os << "LLVM";
+  std::size_t start = 0, idx = code.find('\n');
+  for (; idx != std::string::npos; start = idx, idx = code.find('\n', idx)) os << prefix << std::string_view{code.data() + start, idx - start};
+  os << std::string_view{code.data() + start, code.size() - start} << '\n';
+}
+void cobalt::ast::asm_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {
+  os << "asm";
+  std::size_t start = 0, idx = code.find('\n');
+  for (; idx != std::string::npos; start = idx, idx = code.find('\n', idx)) os << prefix << std::string_view{code.data() + start, idx - start};
+  os << std::string_view{code.data() + start, code.size() - start} << '\n';
+}
+// vars.hpp
+void cobalt::ast::vardef_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {
+  print_self(os, llvm::Twine("vardef: ") + name);
+  print_node(os, prefix, val, true);
+}
+void cobalt::ast::mutdef_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {
+  print_self(os, llvm::Twine("mutdef: ") + name);
+  print_node(os, prefix, val, true);
+}
+void cobalt::ast::varget_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {
+  print_self(os, llvm::Twine("varget: ") + name);
+}


### PR DESCRIPTION
This adds support for pretty-printing of ASTs. Example output:
```
block
├── vardef: x
│    └── constant_int: width: 64, value: 0
└── varget: x
```