### PR TITLE
Remove backward-cpp include

### DIFF
--- a/src/cobalt/macros.cpp
+++ b/src/cobalt/macros.cpp
@@ -90,6 +90,7 @@ macro_map cobalt::default_macros {
     out.reserve(code.size() + 2);
     for (char c : code) {
       if (c >= 32 && c <= 127) out.push_back(c);
+      else if (c == '"') out += "\\\"";
       else {
         char buff[] = "\\x00";
         buff[2] = chars[(unsigned char)c >> 4];

--- a/src/cobalt/tokenizer.cpp
+++ b/src/cobalt/tokenizer.cpp
@@ -3,8 +3,6 @@
 #include <numbers>
 #include <optional>
 #include <llvm/ADT/APInt.h>
-#include <backward.hpp>
-backward::SignalHandling sh;
 #if __cplusplus >= 202002
 #include <bit>
 #define countl1(...) std::countl_one(__VA_ARGS__)


### PR DESCRIPTION
When developing #9, I used [backward-cpp](https://github.com/bombela/backward-cpp) to debug exceptions. When I finished, I forgot to remove it.