### PR TITLE
Add support for parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build/*
 .vscode/*
+stacktrace.cpp
 
 # These will be added later
 std/co/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,9 @@ target_link_libraries(test cobalt)
 add_executable(tokenizer test-programs/tokenizer.cpp)
 target_link_libraries(tokenizer cobalt)
 
+add_executable(parser test-programs/parser.cpp)
+target_link_libraries(parser cobalt)
+
 # build standard library
 include(./cmake/StdLib.cmake)
 add_stdlib(co-std PREFIX __co_ TARGETS std/c/compat.h std/c/std.h std/c/alloc.cpp std/c/file.cpp LIBS c gcc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,9 @@ add_library(cobalt
     include/cobalt/types/types.hpp include/cobalt/types/numeric.hpp include/cobalt/types/pointers.hpp include/cobalt/types/structurals.hpp
     include/cobalt/context.hpp include/cobalt/varmap.hpp include/cobalt/typed_value.hpp
   src/cobalt/tokenizer.cpp src/cobalt/macros.cpp src/cobalt/parser.cpp src/cobalt/print-ast.cpp src/cobalt/codegen.cpp)
+if(CMAKE_BUILD_TYPE STREQUAL Debug AND EXISTS "${PROJECT_SOURCE_DIR}/stacktrace.cpp")
+  target_sources(cobalt PUBLIC "${PROJECT_SOURCE_DIR}/stacktrace.cpp")
+endif()
 add_executable(co src/co/main.cpp)
 target_link_libraries(co cobalt)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,11 +15,11 @@ add_link_options(${LINK_DIR} ${LLVM_LIB})
 include_directories(include)
 add_library(cobalt
   include/cobalt.hpp
-    include/cobalt/ast.hpp include/cobalt/ast/ast.hpp include/cobalt/ast/flow.hpp include/cobalt/ast/meta.hpp include/cobalt/ast/vars.hpp
+    include/cobalt/ast.hpp include/cobalt/ast/ast.hpp include/cobalt/ast/flow.hpp include/cobalt/ast/funcs.hpp include/cobalt/ast/meta.hpp include/cobalt/ast/vars.hpp
     include/cobalt/support/location.hpp include/cobalt/support/sstring.hpp include/cobalt/support/functions.hpp include/cobalt/support/token.hpp
     include/cobalt/types/types.hpp include/cobalt/types/numeric.hpp include/cobalt/types/pointers.hpp include/cobalt/types/structurals.hpp
     include/cobalt/context.hpp include/cobalt/varmap.hpp include/cobalt/typed_value.hpp
-  src/cobalt/tokenizer.cpp src/cobalt/macros.cpp src/cobalt/parser.cpp)
+  src/cobalt/tokenizer.cpp src/cobalt/macros.cpp src/cobalt/parser.cpp src/cobalt/codegen.cpp)
 add_executable(co src/co/main.cpp)
 target_link_libraries(co cobalt)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ add_library(cobalt
     include/cobalt/support/location.hpp include/cobalt/support/sstring.hpp include/cobalt/support/functions.hpp include/cobalt/support/token.hpp
     include/cobalt/types/types.hpp include/cobalt/types/numeric.hpp include/cobalt/types/pointers.hpp include/cobalt/types/structurals.hpp
     include/cobalt/context.hpp include/cobalt/varmap.hpp include/cobalt/typed_value.hpp
-  src/cobalt/tokenizer.cpp src/cobalt/macros.cpp src/cobalt/parser.cpp src/cobalt/codegen.cpp)
+  src/cobalt/tokenizer.cpp src/cobalt/macros.cpp src/cobalt/parser.cpp src/cobalt/print-ast.cpp src/cobalt/codegen.cpp)
 add_executable(co src/co/main.cpp)
 target_link_libraries(co cobalt)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ add_link_options(${LINK_DIR} ${LLVM_LIB})
 include_directories(include)
 add_library(cobalt
   include/cobalt.hpp
-    include/cobalt/ast.hpp include/cobalt/ast/ast.hpp include/cobalt/ast/flow.hpp include/cobalt/ast/funcs.hpp include/cobalt/ast/meta.hpp include/cobalt/ast/vars.hpp
+    include/cobalt/ast.hpp include/cobalt/ast/ast.hpp include/cobalt/ast/flow.hpp include/cobalt/ast/funcs.hpp include/cobalt/ast/meta.hpp include/cobalt/ast/scope.hpp include/cobalt/ast/vars.hpp
     include/cobalt/support/location.hpp include/cobalt/support/sstring.hpp include/cobalt/support/functions.hpp include/cobalt/support/token.hpp
     include/cobalt/types/types.hpp include/cobalt/types/numeric.hpp include/cobalt/types/pointers.hpp include/cobalt/types/structurals.hpp
     include/cobalt/context.hpp include/cobalt/varmap.hpp include/cobalt/typed_value.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ add_link_options(${LINK_DIR} ${LLVM_LIB})
 include_directories(include)
 add_library(cobalt
   include/cobalt.hpp
-    include/cobalt/ast.hpp include/cobalt/ast/ast.hpp include/cobalt/ast/meta.hpp include/cobalt/ast/vars.hpp
+    include/cobalt/ast.hpp include/cobalt/ast/ast.hpp include/cobalt/ast/flow.hpp include/cobalt/ast/meta.hpp include/cobalt/ast/vars.hpp
     include/cobalt/support/location.hpp include/cobalt/support/sstring.hpp include/cobalt/support/functions.hpp include/cobalt/support/token.hpp
     include/cobalt/types/types.hpp include/cobalt/types/numeric.hpp include/cobalt/types/pointers.hpp include/cobalt/types/structurals.hpp
     include/cobalt/context.hpp include/cobalt/varmap.hpp include/cobalt/typed_value.hpp

--- a/include/cobalt/ast.hpp
+++ b/include/cobalt/ast.hpp
@@ -4,5 +4,6 @@
 #include "cobalt/ast/flow.hpp"
 #include "cobalt/ast/funcs.hpp"
 #include "cobalt/ast/meta.hpp"
+#include "cobalt/ast/scope.hpp"
 #include "cobalt/ast/vars.hpp"
 #endif

--- a/include/cobalt/ast.hpp
+++ b/include/cobalt/ast.hpp
@@ -1,4 +1,8 @@
 #ifndef COBALT_AST_HPP
 #define COBALT_AST_HPP
 #include "cobalt/ast/ast.hpp"
+#include "cobalt/ast/flow.hpp"
+#include "cobalt/ast/funcs.hpp"
+#include "cobalt/ast/meta.hpp"
+#include "cobalt/ast/vars.hpp"
 #endif

--- a/include/cobalt/ast/ast.hpp
+++ b/include/cobalt/ast/ast.hpp
@@ -48,8 +48,9 @@ namespace cobalt {
     sstring file() const noexcept {return ptr->loc.file;}
     std::size_t line() const noexcept {return ptr->loc.line;}
     std::size_t col() const noexcept {return ptr->loc.col;}
-    inline typed_value codegen(compile_context& ctx = global) const {return ptr->codegen(ctx);}
-    inline typed_value operator()(compile_context& ctx = global) const {return ptr->codegen(ctx);}
+    typed_value codegen(compile_context& ctx = global) const {return ptr->codegen(ctx);}
+    typed_value operator()(compile_context& ctx = global) const {return ptr->codegen(ctx);}
+    void print(llvm::raw_ostream& os = llvm::outs()) const {ptr->print(os);}
     bool operator==(AST const& other) const {return ptr->eq(other.ptr);}
     explicit operator bool() const noexcept {return (bool)ptr;}
     ast::ast_base* get() const noexcept {return ptr;}

--- a/include/cobalt/ast/ast.hpp
+++ b/include/cobalt/ast/ast.hpp
@@ -3,6 +3,7 @@
 #include "cobalt/support/sstring.hpp"
 #include "cobalt/support/location.hpp"
 #include "cobalt/typed_value.hpp"
+#define CO_INIT(ID) ID(std::move(ID))
 namespace cobalt {
   struct compile_context;
   extern compile_context global;

--- a/include/cobalt/ast/ast.hpp
+++ b/include/cobalt/ast/ast.hpp
@@ -7,6 +7,7 @@
 namespace cobalt {
   struct compile_context;
   extern compile_context global;
+  class AST;
   namespace ast {
     struct ast_base {
       location loc;
@@ -15,14 +16,22 @@ namespace cobalt {
       virtual ~ast_base() noexcept = 0;
       virtual bool eq(ast_base const* other) const = 0;
       typed_value codegen(compile_context& ctx = global) const;
+      void print(llvm::raw_ostream& os) const {print_impl(os, "");}
     private:
       virtual typed_value codegen_impl(compile_context& ctx) const = 0;
+      virtual void print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const = 0;
+      friend class ::cobalt::AST;
+    protected:
+      void print_self(llvm::raw_ostream& os, llvm::Twine name) const;
+      void print_node(llvm::raw_ostream& os, llvm::Twine prefix, AST const& ast, bool last) const;
     };
     inline ast_base::~ast_base() noexcept {}
     inline typed_value ast_base::codegen(compile_context& ctx) const {return codegen_impl(ctx);}
   }
   class AST {
+    friend class ast::ast_base;
     ast::ast_base* ptr;
+    void print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {ptr->print_impl(os, prefix);}
   public:
     AST(std::nullptr_t) noexcept : ptr(nullptr) {}
     AST(ast::ast_base* ptr) noexcept : ptr(ptr) {}
@@ -42,6 +51,10 @@ namespace cobalt {
     inline typed_value codegen(compile_context& ctx = global) const {return ptr->codegen(ctx);}
     inline typed_value operator()(compile_context& ctx = global) const {return ptr->codegen(ctx);}
     bool operator==(AST const& other) const {return ptr->eq(other.ptr);}
+    explicit operator bool() const noexcept {return (bool)ptr;}
+    ast::ast_base* get() const noexcept {return ptr;}
+    template <class T> T* cast() const {return ptr ? static_cast<T*>(ptr) : (T*)ptr;}
+    template <class T> T* dyn_cast() const {return ptr ? dynamic_cast<T*>(ptr) : (T*)ptr;}
     template <class T, class... As> static AST create(As&&... args) {return new T(std::forward<As>(args)...);}
     template <class T, class... As> static AST create_nothrow(As&&... args) noexcept {
       ast::ast_base* ptr;

--- a/include/cobalt/ast/flow.hpp
+++ b/include/cobalt/ast/flow.hpp
@@ -2,6 +2,14 @@
 #define COBALT_AST_FLOW_HPP
 #include "cobalt/ast/ast.hpp"
 namespace cobalt::ast {
+  struct top_level_ast : ast_base {
+    std::vector<AST> insts;
+    top_level_ast(location loc, std::vector<AST>&& insts) : ast_base(loc), CO_INIT(insts) {}
+    bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<top_level_ast const*>(other)) return insts == ptr->insts; else return false;}
+  private: 
+    typed_value codegen_impl(compile_context& ctx) const override;
+    void print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const override;
+  };
   struct block_ast : ast_base {
     std::vector<AST> insts;
     block_ast(location loc, std::vector<AST>&& insts) : ast_base(loc), CO_INIT(insts) {}

--- a/include/cobalt/ast/flow.hpp
+++ b/include/cobalt/ast/flow.hpp
@@ -6,22 +6,26 @@ namespace cobalt::ast {
     std::vector<AST> insts;
     block_ast(location loc, std::vector<AST>&& insts) : ast_base(loc), CO_INIT(insts) {}
     bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<block_ast const*>(other)) return insts == ptr->insts; else return false;}
+  private: typed_value codegen_impl(compile_context& ctx) const override;
   };
   struct if_ast : ast_base {
     AST cond, if_true, if_false;
     if_ast(location loc, AST&& cond, AST&& if_true, AST&& if_false = nullptr) : ast_base(loc), CO_INIT(cond), CO_INIT(if_true), CO_INIT(if_false) {}
     bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<if_ast const*>(other)) return cond == ptr->cond && if_true == ptr->if_true && if_false == ptr->if_false; else return false;}
+  private: typed_value codegen_impl(compile_context& ctx) const override;
   };
   struct while_ast : ast_base {
     AST cond, body;
     while_ast(location loc, AST&& cond, AST&& body) : ast_base(loc), CO_INIT(cond), CO_INIT(body) {}
     bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<while_ast const*>(other)) return cond == ptr->cond && body == ptr->body; else return false;}
+  private: typed_value codegen_impl(compile_context& ctx) const override;
   };
   struct for_ast : ast_base {
     AST cond, body;
     sstring elem_name;
-    while_ast(location loc, AST&& cond, AST&& body) : ast_base(loc), CO_INIT(cond), CO_INIT(body) {}
+    for_ast(location loc, sstring elem_name, AST&& cond, AST&& body) : ast_base(loc), CO_INIT(cond), CO_INIT(body), elem_name(elem_name) {}
     bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<while_ast const*>(other)) return cond == ptr->cond && body == ptr->body; else return false;}
+  private: typed_value codegen_impl(compile_context& ctx) const override;
   };
 }
 #endif

--- a/include/cobalt/ast/flow.hpp
+++ b/include/cobalt/ast/flow.hpp
@@ -1,0 +1,27 @@
+#ifndef COBALT_AST_FLOW_HPP
+#define COBALT_AST_FLOW_HPP
+#include "cobalt/ast/ast.hpp"
+namespace cobalt::ast {
+  struct block_ast : ast_base {
+    std::vector<AST> insts;
+    block_ast(location loc, std::vector<AST>&& insts) : ast_base(loc), CO_INIT(insts) {}
+    bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<block_ast const*>(other)) return insts == ptr->insts; else return false;}
+  };
+  struct if_ast : ast_base {
+    AST cond, if_true, if_false;
+    if_ast(location loc, AST&& cond, AST&& if_true, AST&& if_false = nullptr) : ast_base(loc), CO_INIT(cond), CO_INIT(if_true), CO_INIT(if_false) {}
+    bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<if_ast const*>(other)) return cond == ptr->cond && if_true == ptr->if_true && if_false == ptr->if_false; else return false;}
+  };
+  struct while_ast : ast_base {
+    AST cond, body;
+    while_ast(location loc, AST&& cond, AST&& body) : ast_base(loc), CO_INIT(cond), CO_INIT(body) {}
+    bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<while_ast const*>(other)) return cond == ptr->cond && body == ptr->body; else return false;}
+  };
+  struct for_ast : ast_base {
+    AST cond, body;
+    sstring elem_name;
+    while_ast(location loc, AST&& cond, AST&& body) : ast_base(loc), CO_INIT(cond), CO_INIT(body) {}
+    bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<while_ast const*>(other)) return cond == ptr->cond && body == ptr->body; else return false;}
+  };
+}
+#endif

--- a/include/cobalt/ast/flow.hpp
+++ b/include/cobalt/ast/flow.hpp
@@ -6,26 +6,34 @@ namespace cobalt::ast {
     std::vector<AST> insts;
     block_ast(location loc, std::vector<AST>&& insts) : ast_base(loc), CO_INIT(insts) {}
     bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<block_ast const*>(other)) return insts == ptr->insts; else return false;}
-  private: typed_value codegen_impl(compile_context& ctx) const override;
+  private: 
+    typed_value codegen_impl(compile_context& ctx) const override;
+    void print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const override;
   };
   struct if_ast : ast_base {
     AST cond, if_true, if_false;
     if_ast(location loc, AST&& cond, AST&& if_true, AST&& if_false = nullptr) : ast_base(loc), CO_INIT(cond), CO_INIT(if_true), CO_INIT(if_false) {}
     bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<if_ast const*>(other)) return cond == ptr->cond && if_true == ptr->if_true && if_false == ptr->if_false; else return false;}
-  private: typed_value codegen_impl(compile_context& ctx) const override;
+  private: 
+    typed_value codegen_impl(compile_context& ctx) const override;
+    void print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const override;
   };
   struct while_ast : ast_base {
     AST cond, body;
     while_ast(location loc, AST&& cond, AST&& body) : ast_base(loc), CO_INIT(cond), CO_INIT(body) {}
     bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<while_ast const*>(other)) return cond == ptr->cond && body == ptr->body; else return false;}
-  private: typed_value codegen_impl(compile_context& ctx) const override;
+  private: 
+    typed_value codegen_impl(compile_context& ctx) const override;
+    void print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const override;
   };
   struct for_ast : ast_base {
     AST cond, body;
     sstring elem_name;
     for_ast(location loc, sstring elem_name, AST&& cond, AST&& body) : ast_base(loc), CO_INIT(cond), CO_INIT(body), elem_name(elem_name) {}
     bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<while_ast const*>(other)) return cond == ptr->cond && body == ptr->body; else return false;}
-  private: typed_value codegen_impl(compile_context& ctx) const override;
+  private: 
+    typed_value codegen_impl(compile_context& ctx) const override;
+    void print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const override;
   };
 }
 #endif

--- a/include/cobalt/ast/funcs.hpp
+++ b/include/cobalt/ast/funcs.hpp
@@ -1,0 +1,25 @@
+#ifndef COBALT_AST_FUNCS_HPP
+#define COBALT_AST_FUNCS_HPP
+#include "cobalt/ast/ast.hpp"
+#include "cobalt/types/types.hpp"
+namespace cobalt::ast {
+  struct binop_ast : ast_base {
+    sstring op;
+    AST lhs, rhs;
+    binop_ast(location loc, sstring op, AST&& lhs, AST&& rhs) : ast_base(loc), op(op), CO_INIT(lhs), CO_INIT(rhs) {}
+    bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<binop_ast const*>(other) return op == ptr->op && lhs == ptr->lhs && rhs == ptr->rhs; else return false;}
+  };
+  struct call_ast {
+    sstring name;
+    std::vector<AST> args;
+    binop_ast(location loc, sstring name, std::vector<AST>&& args) : ast_base(loc), name(name), CO_INIT(args) {}
+    bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<call_ast const*>(other) return op == ptr->op && args == ptr->args; else return false;}
+  };
+  struct fndef_ast {
+    sstring name;
+    std::vector<type_ptr> args;
+    fndef_ast(location loc, sstring name, std::vector<type_ptr>&& args) : ast_base(loc), name(name), CO_INIT(args) {}
+    bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<call_ast const*>(other) return op == ptr->op && args == ptr->args; else return false;}
+  };
+}
+#endif

--- a/include/cobalt/ast/funcs.hpp
+++ b/include/cobalt/ast/funcs.hpp
@@ -7,19 +7,29 @@ namespace cobalt::ast {
     sstring op;
     AST lhs, rhs;
     binop_ast(location loc, sstring op, AST&& lhs, AST&& rhs) : ast_base(loc), op(op), CO_INIT(lhs), CO_INIT(rhs) {}
-    bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<binop_ast const*>(other) return op == ptr->op && lhs == ptr->lhs && rhs == ptr->rhs; else return false;}
+    bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<binop_ast const*>(other)) return op == ptr->op && lhs == ptr->lhs && rhs == ptr->rhs; else return false;}
+  private: typed_value codegen_impl(compile_context& ctx) const override;
   };
-  struct call_ast {
+  struct unop_ast : ast_base {
+    sstring op;
+    AST val;
+    unop_ast(location loc, sstring op, AST&& val) : ast_base(loc), op(op), CO_INIT(val) {}
+    bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<unop_ast const*>(other)) return op == ptr->op && val == ptr->val; else return false;}
+  private: typed_value codegen_impl(compile_context& ctx) const override;
+  };
+  struct call_ast : ast_base {
     sstring name;
     std::vector<AST> args;
-    binop_ast(location loc, sstring name, std::vector<AST>&& args) : ast_base(loc), name(name), CO_INIT(args) {}
-    bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<call_ast const*>(other) return op == ptr->op && args == ptr->args; else return false;}
+    call_ast(location loc, sstring name, std::vector<AST>&& args) : ast_base(loc), name(name), CO_INIT(args) {}
+    bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<call_ast const*>(other)) return name == ptr->name && args == ptr->args; else return false;}
+  private: typed_value codegen_impl(compile_context& ctx) const override;
   };
-  struct fndef_ast {
+  struct fndef_ast : ast_base {
     sstring name;
     std::vector<type_ptr> args;
     fndef_ast(location loc, sstring name, std::vector<type_ptr>&& args) : ast_base(loc), name(name), CO_INIT(args) {}
-    bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<call_ast const*>(other) return op == ptr->op && args == ptr->args; else return false;}
+    bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<fndef_ast const*>(other)) return name == ptr->name && args == ptr->args; else return false;}
+  private: typed_value codegen_impl(compile_context& ctx) const override;
   };
 }
 #endif

--- a/include/cobalt/ast/funcs.hpp
+++ b/include/cobalt/ast/funcs.hpp
@@ -8,28 +8,36 @@ namespace cobalt::ast {
     AST lhs, rhs;
     binop_ast(location loc, sstring op, AST&& lhs, AST&& rhs) : ast_base(loc), op(op), CO_INIT(lhs), CO_INIT(rhs) {}
     bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<binop_ast const*>(other)) return op == ptr->op && lhs == ptr->lhs && rhs == ptr->rhs; else return false;}
-  private: typed_value codegen_impl(compile_context& ctx) const override;
+  private: 
+    typed_value codegen_impl(compile_context& ctx) const override;
+    void print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const override;
   };
   struct unop_ast : ast_base {
     sstring op;
     AST val;
     unop_ast(location loc, sstring op, AST&& val) : ast_base(loc), op(op), CO_INIT(val) {}
     bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<unop_ast const*>(other)) return op == ptr->op && val == ptr->val; else return false;}
-  private: typed_value codegen_impl(compile_context& ctx) const override;
+  private: 
+    typed_value codegen_impl(compile_context& ctx) const override;
+    void print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const override;
   };
   struct call_ast : ast_base {
     sstring name;
     std::vector<AST> args;
     call_ast(location loc, sstring name, std::vector<AST>&& args) : ast_base(loc), name(name), CO_INIT(args) {}
     bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<call_ast const*>(other)) return name == ptr->name && args == ptr->args; else return false;}
-  private: typed_value codegen_impl(compile_context& ctx) const override;
+  private: 
+    typed_value codegen_impl(compile_context& ctx) const override;
+    void print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const override;
   };
   struct fndef_ast : ast_base {
     sstring name;
     std::vector<type_ptr> args;
     fndef_ast(location loc, sstring name, std::vector<type_ptr>&& args) : ast_base(loc), name(name), CO_INIT(args) {}
     bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<fndef_ast const*>(other)) return name == ptr->name && args == ptr->args; else return false;}
-  private: typed_value codegen_impl(compile_context& ctx) const override;
+  private: 
+    typed_value codegen_impl(compile_context& ctx) const override;
+    void print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const override;
   };
 }
 #endif

--- a/include/cobalt/ast/meta.hpp
+++ b/include/cobalt/ast/meta.hpp
@@ -5,12 +5,16 @@ namespace cobalt::ast {
   struct llvm_ast : ast_base {
     std::string code;
     llvm_ast(location loc, std::string&& code) : ast_base(loc), code(std::move(code)) {}
-    private: typed_value codegen_impl(compile_context& ctx) const override;
+    private: 
+    typed_value codegen_impl(compile_context& ctx) const override;
+    void print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const override;
   };
   struct asm_ast : ast_base {
     std::string code;
     asm_ast(location loc, std::string&& code) : ast_base(loc), code(std::move(code)) {}
-    private: typed_value codegen_impl(compile_context& ctx) const override;
+    private: 
+    typed_value codegen_impl(compile_context& ctx) const override;
+    void print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const override;
   };
 }
 #endif

--- a/include/cobalt/ast/meta.hpp
+++ b/include/cobalt/ast/meta.hpp
@@ -2,11 +2,6 @@
 #define COBALT_AST_META_HPP
 #include "ast.hpp"
 namespace cobalt::ast {
-  struct embed_ast : ast_base {
-    std::string code;
-    embed_ast(std::string&& code, location loc) : ast_base(loc), code(std::move(code)) {}
-    private: typed_value codegen_impl(compile_context& ctx) const override;
-  };
   struct llvm_ast : ast_base {
     std::string code;
     llvm_ast(std::string&& code, location loc) : ast_base(loc), code(std::move(code)) {}

--- a/include/cobalt/ast/meta.hpp
+++ b/include/cobalt/ast/meta.hpp
@@ -1,15 +1,15 @@
 #ifndef COBALT_AST_META_HPP
 #define COBALT_AST_META_HPP
-#include "ast.hpp"
+#include "cobalt/ast/ast.hpp"
 namespace cobalt::ast {
   struct llvm_ast : ast_base {
     std::string code;
-    llvm_ast(std::string&& code, location loc) : ast_base(loc), code(std::move(code)) {}
+    llvm_ast(location loc, std::string&& code) : ast_base(loc), code(std::move(code)) {}
     private: typed_value codegen_impl(compile_context& ctx) const override;
   };
   struct asm_ast : ast_base {
     std::string code;
-    asm_ast(std::string&& code, location loc) : ast_base(loc), code(std::move(code)) {}
+    asm_ast(location loc, std::string&& code) : ast_base(loc), code(std::move(code)) {}
     private: typed_value codegen_impl(compile_context& ctx) const override;
   };
 }

--- a/include/cobalt/ast/scope.hpp
+++ b/include/cobalt/ast/scope.hpp
@@ -1,0 +1,29 @@
+#ifndef COBALT_AST_SCOPE_HPP
+#define COBALT_AST_SCOPE_HPP
+#include "cobalt/ast/ast.hpp"
+namespace cobalt::ast {
+  struct module_ast : ast_base {
+    std::string name;
+    std::vector<AST> insts;
+    module_ast(location loc, std::string&& name, std::vector<AST>&& insts) : ast_base(loc), CO_INIT(name), CO_INIT(insts) {}
+    ~module_ast();
+    bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<module_ast const*>(other)) return name == ptr->name && insts == ptr->insts; else return false;}
+  private:
+    typed_value codegen_impl(compile_context& ctx) const override;
+    void print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const override;
+  };
+  struct import_ast : ast_base {
+    std::string path;
+    import_ast(location loc, std::string&& path) : ast_base(loc), CO_INIT(path) {}
+    ~import_ast();
+    bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<import_ast const*>(other)) return path == ptr->path; else return false;}
+  private:
+    typed_value codegen_impl(compile_context& ctx) const override;
+    void print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const override;
+  };
+
+
+  inline module_ast::~module_ast() {}
+  inline import_ast::~import_ast() {}
+}
+#endif

--- a/include/cobalt/ast/vars.hpp
+++ b/include/cobalt/ast/vars.hpp
@@ -8,20 +8,26 @@ namespace cobalt {
       AST val;
       vardef_ast(location loc, sstring name, AST&& val) : ast_base(loc), name(name), CO_INIT(val) {}
       bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<vardef_ast const*>(other)) return name == ptr->name && val == ptr->val; else return false;}
-    private: typed_value codegen_impl(compile_context& ctx) const override;
+    private: 
+    typed_value codegen_impl(compile_context& ctx) const override;
+    void print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const override;
     };
     struct mutdef_ast : ast_base {
       sstring name;
       AST val;
       mutdef_ast(location loc, sstring name, AST&& val) : ast_base(loc), name(name), CO_INIT(val) {}
       bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<mutdef_ast const*>(other)) return name == ptr->name && val == ptr->val; else return false;}
-    private: typed_value codegen_impl(compile_context& ctx) const override;
+    private: 
+    typed_value codegen_impl(compile_context& ctx) const override;
+    void print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const override;
     };
     struct varget_ast : ast_base {
       sstring name;
       varget_ast(location loc, sstring name) : ast_base(loc), name(name) {}
       bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<varget_ast const*>(other)) return name == ptr->name; else return false;}
-      private: typed_value codegen_impl(compile_context& ctx) const override;
+      private: 
+    typed_value codegen_impl(compile_context& ctx) const override;
+    void print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const override;
     };
   }
 }

--- a/include/cobalt/ast/vars.hpp
+++ b/include/cobalt/ast/vars.hpp
@@ -4,13 +4,24 @@
 namespace cobalt {
   namespace ast {
     struct vardef_ast : ast_base {
-      typed_value codegen(compile_context& ctx) const override;
+      sstring name;
+      AST val;
+      vardef_ast(location loc, sstring name, AST&& val) : ast_base(loc), name(name), CO_INIT(val) {}
+      bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<vardef_ast const*>(other)) return name == ptr->name && val == ptr->val; else return false;}
+    private: typed_value codegen_impl(compile_context& ctx) const override;
     };
     struct mutdef_ast : ast_base {
-      typed_value codegen(compile_context& ctx) const override;
+      sstring name;
+      AST val;
+      mutdef_ast(location loc, sstring name, AST&& val) : ast_base(loc), name(name), CO_INIT(val) {}
+      bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<mutdef_ast const*>(other)) return name == ptr->name && val == ptr->val; else return false;}
+    private: typed_value codegen_impl(compile_context& ctx) const override;
     };
     struct varget_ast : ast_base {
-      typed_value codegen(compile_context& ctx) const override;
+      sstring name;
+      varget_ast(location loc, sstring name) : ast_base(loc), name(name) {}
+      bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<varget_ast const*>(other)) return name == ptr->name; else return false;}
+      private: typed_value codegen_impl(compile_context& ctx) const override;
     };
   }
 }

--- a/include/cobalt/support/location.hpp
+++ b/include/cobalt/support/location.hpp
@@ -12,5 +12,6 @@ namespace cobalt {
   inline bool operator==(location const& lhs, location const& rhs) {return lhs.file == rhs.file && lhs.line == rhs.line && lhs.col == rhs.col;}
   inline bool operator!=(location const& lhs, location const& rhs) {return lhs.file != rhs.file || lhs.line != rhs.line || lhs.col != rhs.col;}
   template <class T> inline auto& operator<<(T& os, location const& loc) {return os << loc.file << ':' << loc.line << ':' << loc.col;}
+  inline location nullloc = {sstring::get(""), 0, 0};
 }
 #endif

--- a/include/cobalt/typed_value.hpp
+++ b/include/cobalt/typed_value.hpp
@@ -7,5 +7,6 @@ namespace cobalt {
     llvm::Value* value;
     types::type_base const* type;
   };
+  inline typed_value nullval {nullptr, nullptr};
 }
 #endif

--- a/include/cobalt/types/types.hpp
+++ b/include/cobalt/types/types.hpp
@@ -18,7 +18,7 @@ namespace cobalt {
       virtual std::size_t align() const = 0;
       virtual llvm::Type* llvm_type(location loc, compile_context& ctx) const = 0;
     };
-    inline type_base::~type_base() {(void);}
+    inline type_base::~type_base() {}
   }
   using type_ptr = types::type_base const*;
 }

--- a/src/cobalt/codegen.cpp
+++ b/src/cobalt/codegen.cpp
@@ -1,0 +1,18 @@
+#include "cobalt/ast.hpp"
+using namespace cobalt;
+// flow.hpp
+typed_value cobalt::ast::block_ast::codegen_impl(compile_context& ctx) const {(void)ctx; return nullval;}
+typed_value cobalt::ast::if_ast::codegen_impl(compile_context& ctx) const {(void)ctx; return nullval;}
+typed_value cobalt::ast::while_ast::codegen_impl(compile_context& ctx) const {(void)ctx; return nullval;}
+typed_value cobalt::ast::for_ast::codegen_impl(compile_context& ctx) const {(void)ctx; return nullval;}
+// funcs.hpp
+typed_value cobalt::ast::binop_ast::codegen_impl(compile_context& ctx) const {(void)ctx; return nullval;}
+typed_value cobalt::ast::call_ast::codegen_impl(compile_context& ctx) const {(void)ctx; return nullval;}
+typed_value cobalt::ast::fndef_ast::codegen_impl(compile_context& ctx) const {(void)ctx; return nullval;}
+// meta.hpp
+typed_value cobalt::ast::llvm_ast::codegen_impl(compile_context& ctx) const {(void)ctx; return nullval;}
+typed_value cobalt::ast::asm_ast::codegen_impl(compile_context& ctx) const {(void)ctx; return nullval;}
+// vars.hpp
+typed_value cobalt::ast::vardef_ast::codegen_impl(compile_context& ctx) const {(void)ctx; return nullval;}
+typed_value cobalt::ast::mutdef_ast::codegen_impl(compile_context& ctx) const {(void)ctx; return nullval;}
+typed_value cobalt::ast::varget_ast::codegen_impl(compile_context& ctx) const {(void)ctx; return nullval;}

--- a/src/cobalt/codegen.cpp
+++ b/src/cobalt/codegen.cpp
@@ -13,6 +13,9 @@ typed_value cobalt::ast::fndef_ast::codegen_impl(compile_context& ctx) const {(v
 // meta.hpp
 typed_value cobalt::ast::llvm_ast::codegen_impl(compile_context& ctx) const {(void)ctx; return nullval;}
 typed_value cobalt::ast::asm_ast::codegen_impl(compile_context& ctx) const {(void)ctx; return nullval;}
+// scope.hpp
+typed_value cobalt::ast::module_ast::codegen_impl(compile_context& ctx) const {(void)ctx; return nullval;}
+typed_value cobalt::ast::import_ast::codegen_impl(compile_context& ctx) const {(void)ctx; return nullval;}
 // vars.hpp
 typed_value cobalt::ast::vardef_ast::codegen_impl(compile_context& ctx) const {(void)ctx; return nullval;}
 typed_value cobalt::ast::mutdef_ast::codegen_impl(compile_context& ctx) const {(void)ctx; return nullval;}

--- a/src/cobalt/codegen.cpp
+++ b/src/cobalt/codegen.cpp
@@ -1,6 +1,7 @@
 #include "cobalt/ast.hpp"
 using namespace cobalt;
 // flow.hpp
+typed_value cobalt::ast::top_level_ast::codegen_impl(compile_context& ctx) const {(void)ctx; return nullval;}
 typed_value cobalt::ast::block_ast::codegen_impl(compile_context& ctx) const {(void)ctx; return nullval;}
 typed_value cobalt::ast::if_ast::codegen_impl(compile_context& ctx) const {(void)ctx; return nullval;}
 typed_value cobalt::ast::while_ast::codegen_impl(compile_context& ctx) const {(void)ctx; return nullval;}

--- a/src/cobalt/parser.cpp
+++ b/src/cobalt/parser.cpp
@@ -16,12 +16,132 @@ std::vector<std::string_view> bin_ops[] {
 };
 std::string_view pre_ops[] = {"+", "-", "*", "!", "~", "++", "--"};
 std::string_view post_ops[] = {"?", "!"};
-AST parse_expr(span<token> code, flags_t flags) {
-  
+std::vector<std::string> parse_paths(span<token>::iterator& it, span<token>::iterator end, flags_t flags) {
+  std::vector<std::string> paths = {""};
+  auto pball = [&paths] (std::string_view sv) {for (auto& str : paths) str += sv;};
+  uint8_t lwp = 2;
+  while (++it != end) {
+    std::string_view data = it->data;
+    switch (data.front()) {
+      case '{':
+      case '}':
+      case ',':
+        flags.onerror(it->loc, "compound pattern matching is not currently supported", CRITICAL);
+        break;
+      case ';':
+        return paths;
+        break;
+      case '*':
+        if ((it + 1)->data == "*") {
+          while (++it != end && it->data == "*");
+          flags.onerror(it->loc, "recursive pattern matching is not currently supported", WARNING);
+        }
+        lwp = 0;
+        pball("*");
+        break;
+      case '.':
+        if (lwp == 1) flags.onerror(it->loc, "consecutive periods are not allowed in paths", ERROR);
+        pball(".");
+        lwp = 1;
+        break;
+      default:
+        if (lwp != 0) pball(data);
+        else {
+          flags.onerror(it->loc, "imported identifier paths should be separated by a period or terminated by a semicolon", ERROR);
+          return paths;
+        }
+        lwp = 0;
+    }
+  }
+  return paths;
+}
+std::pair<std::vector<AST>, span<token>::iterator> parse_tl(span<token> code, flags_t flags) {
+#define UNSUPPORTED(TYPE) {flags.onerror(it->loc, "top-level " TYPE " definitions are not currently supported", CRITICAL);}
+  if (code.empty()) return {std::vector<AST>{}, code.end()};
+  std::vector<AST> tl_nodes;
+  const auto end = code.end();
+  for (auto it = code.begin(); it != end; ++it) {
+    std::string_view tok = it->data;
+    switch (tok.front()) {
+      case ';': break;
+      case 'm':
+        if (tok == "module") {
+          auto start = it->loc;
+          std::string module_path;
+          uint8_t lwp = 2; // last was period; 0=false, 1=true, 2=start
+          while (++it != end) {
+            std::string_view tok = it->data;
+            switch (tok.front()) {
+              case ';': tl_nodes.push_back(AST::create<ast::module_ast>(start, std::move(module_path), std::vector<AST>{})); goto MODULE_END; // empty module declaration
+              case '{': // module definition
+                {
+                  auto [asts, it2] = parse_tl({++it, code.end()}, flags);
+                  tl_nodes.push_back(AST::create<ast::module_ast>(start, std::move(module_path), std::move(asts)));
+                  it = it2;
+                }
+                if (it == code.end()) {
+                  flags.onerror((it - 1)->loc, "unterminated module definition", ERROR);
+                }
+                goto MODULE_END;
+              case '"': flags.onerror(it->loc, "module path cannot contain a string literal", ERROR); goto MODULE_END;
+              case '\'': flags.onerror(it->loc, "module path cannot contain a character literal", ERROR); goto MODULE_END;
+              case '0':
+              case '1':
+                flags.onerror(it->loc, "module path cannot contain a numeric literal", ERROR);
+                goto MODULE_END;
+              case '.':
+                if (lwp == 1) flags.onerror(it->loc, "module path cannot contain consecutive periods", ERROR);
+                else module_path.push_back('.');
+                lwp = 1;
+                break;
+              default:
+                if (lwp == 0) {
+                  flags.onerror(it->loc, "module path cannot contain consecutive identifiers, did you forget a period?", ERROR);
+                  module_path.push_back('.');
+                }
+                lwp = 0;
+                module_path += tok;
+                break;
+            }
+          }
+          MODULE_END:;
+        }
+        else if (tok == "mut") UNSUPPORTED("variable")
+        else if (tok == "mixin") UNSUPPORTED("mixin")
+        else goto CP_DEFAULT;
+        break;
+      case 's':
+        if (tok == "struct") UNSUPPORTED("struct")
+        else goto CP_DEFAULT;
+        break;
+      case 'f':
+        if (tok == "func") UNSUPPORTED("function")
+        else goto CP_DEFAULT;
+        break;
+      case 'l':
+        if (tok == "let") UNSUPPORTED("variable")
+        else goto CP_DEFAULT;
+        break;
+      case 'i':
+        if (tok == "import") {
+          location start = it->loc;
+          for (auto& path : parse_paths(it, code.end(), flags)) tl_nodes.push_back(AST::create<ast::import_ast>(start, std::move(path)));
+        }
+        else goto CP_DEFAULT;
+        break;
+      case '}': return {std::move(tl_nodes), it};
+      default: CP_DEFAULT:
+        flags.onerror(it->loc, (llvm::Twine("invalid top-level token '") + it->data + "'").str(), ERROR);
+    }
+  }
+  return {std::move(tl_nodes), code.end()};
 }
 AST cobalt::parse(span<token> code, flags_t flags) {
-  AST ast = AST::create<ast::block_ast, std::vector<AST>&&>({});
-  (void)code;
-  (void)flags;
-  return ast;
+  if (code.empty()) return nullptr;
+  auto [asts, end] = parse_tl(code, flags);
+  if (end != code.end()) {
+    flags.onerror(end->loc, "unexpected closing brace", ERROR);
+    return nullptr;
+  }
+  return AST::create<ast::top_level_ast>(code.front().loc, std::move(asts));
 }

--- a/src/cobalt/parser.cpp
+++ b/src/cobalt/parser.cpp
@@ -1,8 +1,27 @@
 #include "cobalt/parser.hpp"
 #include "cobalt/ast.hpp"
 using namespace cobalt;
+std::vector<std::string_view> bin_ops[] {
+  {"=", "+=", "-=", "*=", "/=", "%=", "&=", "|=", "^=", "<<=", ">>=", "^^="},
+  {"||"},
+  {"&&"},
+  {"==", "!="},
+  {"<", "<=", ">", ">="},
+  {"|"},
+  {"&"},
+  {"<<", ">>"},
+  {"+", "-"},
+  {"*", "/", "%"},
+  {"^^"}
+};
+std::string_view pre_ops[] = {"+", "-", "*", "!", "~", "++", "--"};
+std::string_view post_ops[] = {"?", "!"};
+AST parse_expr(span<token> code, flags_t flags) {
+  
+}
 AST cobalt::parse(span<token> code, flags_t flags) {
+  AST ast = AST::create<ast::block_ast, std::vector<AST>&&>({});
   (void)code;
   (void)flags;
-  return nullptr;
+  return ast;
 }

--- a/src/cobalt/print-ast.cpp
+++ b/src/cobalt/print-ast.cpp
@@ -4,7 +4,7 @@ using namespace cobalt;
 void cobalt::ast::ast_base::print_self(llvm::raw_ostream& os, llvm::Twine name) const {os << name + "\n";}
 void cobalt::ast::ast_base::print_node(llvm::raw_ostream& os, llvm::Twine prefix, AST const& ast, bool last) const {
   os << prefix + (last ? "└── ": "├── ");
-  ast.print_impl(os, prefix + (last ? "    " : "|   "));
+  ast.print_impl(os, prefix + (last ? "    " : "│   "));
 }
 // flow.hpp
 void cobalt::ast::block_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {

--- a/src/cobalt/print-ast.cpp
+++ b/src/cobalt/print-ast.cpp
@@ -1,0 +1,84 @@
+#include "cobalt/ast.hpp"
+using namespace cobalt;
+// ast.hpp
+void cobalt::ast::ast_base::print_self(llvm::raw_ostream& os, llvm::Twine name) const {os << name + "\n";}
+void cobalt::ast::ast_base::print_node(llvm::raw_ostream& os, llvm::Twine prefix, AST const& ast, bool last) const {
+  os << prefix + (last ? "└── ": "├── ");
+  ast.print_impl(os, prefix + (last ? "    " : "|   "));
+}
+// flow.hpp
+void cobalt::ast::block_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {
+  print_self(os, "block");
+  if (insts.empty()) return;
+  auto last = &insts.back();
+  for (auto const& ast : insts) print_node(os, prefix, ast, &ast == last);
+}
+void cobalt::ast::if_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {
+  if (if_false) {
+    print_self(os, "if/else");
+    print_node(os, prefix, cond, false);
+    print_node(os, prefix, if_true, false);
+    print_node(os, prefix, if_false, true);
+  }
+  else {
+    print_self(os, "if");
+    print_node(os, prefix, cond, false);
+    print_node(os, prefix, if_true, true);
+  }
+}
+void cobalt::ast::while_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {
+  print_self(os, "while");
+  print_node(os, prefix, cond, false);
+  print_node(os, prefix, body, true);
+}
+void cobalt::ast::for_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {
+  print_self(os, llvm::Twine("for: ") + elem_name);
+  print_node(os, prefix, cond, false);
+  print_node(os, prefix, body, true);
+}
+// funcs.hpp
+void cobalt::ast::binop_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {
+  print_self(os, llvm::Twine("op: ") + op);
+  print_node(os, prefix, lhs, false);
+  print_node(os, prefix, rhs, true);
+}
+void cobalt::ast::unop_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {
+  print_self(os, llvm::Twine("op: ") + op);
+  print_node(os, prefix, val, true);
+}
+void cobalt::ast::call_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {
+  print_self(os, llvm::Twine("call: ") + name);
+  if (args.empty()) return;
+  auto last = &args.back();
+  for (auto const& ast : args) print_node(os, prefix, ast, &ast == last);
+}
+void cobalt::ast::fndef_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {
+  os << llvm::Twine("fndef: ") + name + ", args: ";
+  auto last = &args.back();
+  for (auto const& type : args) os << (&type == last ? llvm::Twine(type->name()) + "\n" : llvm::Twine(type->name()) + ", ");
+}
+// meta.hpp
+void cobalt::ast::llvm_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {
+  os << "LLVM";
+  std::size_t start = 0, idx = code.find('\n');
+  for (; idx != std::string::npos; start = idx, idx = code.find('\n', idx)) os << prefix << std::string_view{code.data() + start, idx - start};
+  os << std::string_view{code.data() + start, code.size() - start} << '\n';
+}
+void cobalt::ast::asm_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {
+  os << "asm";
+  std::size_t start = 0, idx = code.find('\n');
+  for (; idx != std::string::npos; start = idx, idx = code.find('\n', idx)) os << prefix << std::string_view{code.data() + start, idx - start};
+  os << std::string_view{code.data() + start, code.size() - start} << '\n';
+}
+// vars.hpp
+void cobalt::ast::vardef_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {
+  print_self(os, llvm::Twine("vardef: ") + name);
+  print_node(os, prefix, val, true);
+}
+void cobalt::ast::mutdef_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {
+  print_self(os, llvm::Twine("mutdef: ") + name);
+  print_node(os, prefix, val, true);
+}
+void cobalt::ast::varget_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {
+  print_self(os, llvm::Twine("varget: ") + name);
+}

--- a/src/cobalt/print-ast.cpp
+++ b/src/cobalt/print-ast.cpp
@@ -76,6 +76,16 @@ void cobalt::ast::asm_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix)
   for (; idx != std::string::npos; start = idx, idx = code.find('\n', idx)) os << prefix << std::string_view{code.data() + start, idx - start};
   os << std::string_view{code.data() + start, code.size() - start} << '\n';
 }
+// scope.hpp
+void cobalt::ast::module_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {
+  print_self(os, llvm::Twine("module ") + name);
+  if (insts.empty()) return;
+  auto last = &insts.back();
+  for (auto const& ast : insts) print_node(os, prefix, ast, &ast == last);
+}
+void cobalt::ast::import_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {
+  print_self(os, llvm::Twine("import: ") + path);
+}
 // vars.hpp
 void cobalt::ast::vardef_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {
   print_self(os, llvm::Twine("vardef: ") + name);

--- a/src/cobalt/print-ast.cpp
+++ b/src/cobalt/print-ast.cpp
@@ -7,6 +7,12 @@ void cobalt::ast::ast_base::print_node(llvm::raw_ostream& os, llvm::Twine prefix
   ast.print_impl(os, prefix + (last ? "    " : "|   "));
 }
 // flow.hpp
+void cobalt::ast::top_level_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {
+  print_self(os, "top level");
+  if (insts.empty()) return;
+  auto last = &insts.back();
+  for (auto const& ast : insts) print_node(os, prefix, ast, &ast == last);
+}
 void cobalt::ast::block_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {
   print_self(os, "block");
   if (insts.empty()) return;

--- a/test-programs/parser.cpp
+++ b/test-programs/parser.cpp
@@ -1,0 +1,26 @@
+#include "cobalt/tokenizer.hpp"
+#include "cobalt/parser.hpp"
+#include "cobalt/ast.hpp"
+#include <iostream>
+#include <fstream>
+int main(int argc, char** argv) {
+  cobalt::flags_t flags = cobalt::default_flags;
+  cobalt::default_handler_t handler;
+  flags.onerror = handler;
+  bool fail = false;
+  std::string str;
+  for (auto it = argv + 1; it != argv + argc; ++it) {
+    handler = cobalt::default_handler;
+    std::string_view file = *it;
+    if (file == "-") str.assign(std::istreambuf_iterator<char>{std::cin}, {});
+    else {
+      std::ifstream ifs(file.data());
+      str.assign(std::istreambuf_iterator<char>{ifs}, {});
+    }
+    auto toks = cobalt::tokenize(str, cobalt::sstring::get(file == "-" ? "<stdin>" : file));
+    cobalt::AST ast = cobalt::parse({toks.begin(), toks.end()}, flags);
+    ast.print();
+    fail |= handler.errors;
+  }
+  return fail;
+}


### PR DESCRIPTION
This merges changes from the `dev.parse` branch, including:

- Various new AST nodes
- The `parser` executable
- Top-level `module` and `import` declarations