### PR TITLE
Update standard library

### DIFF
--- a/std/c/misc.cpp
+++ b/std/c/misc.cpp
@@ -1,0 +1,7 @@
+#include "std.h"
+#include <cstdlib>
+EXPORT void CALL __co_abort(int code) {std::abort(code);}
+EXPORT void CALL __co_exit(int code) {std::exit(code);}
+EXPORT void CALL __co_quick_exit(int code) {std::quick_exit(code);}
+EXPORT void CALL __co_atexit(void(*handler)()) {std::atexit(handler);}
+EXPORT void CALL __co_at_quick_exit(void(*handler)()) {std::at_quick_exit(handler);}

--- a/std/c/std.h
+++ b/std/c/std.h
@@ -25,4 +25,22 @@ IMPORT optional_int8_t CALL __co_fgetc(void* stream);
 IMPORT optional_int8_t CALL __co_fputc(uint8_t ch, void* stream);
 IMPORT int64_t CALL __co_ftell(void* stream);
 IMPORT bool CALL __co_fseek(void* stream, int64_t offset, int8_t origin);
+// miscellaneous utilities
+IMPORT void CALL __co_abort(int code);
+IMPORT void CALL __co_exit(int code);
+IMPORT void CALL __co_quick_exit(int code);
+IMPORT void CALL __co_atexit(void(*handler)());
+IMPORT void CALL __co_at_quick_exit(void(*handler)());
+// string operations
+IMPORT uint64_t CALL __co_strlen(char const* str);
+IMPORT  int64_t CALL __co_strcmp(char const* lhs, char const* rhs);
+IMPORT  int64_t CALL __co_strncmp(char const* lhs, char const* rhs, uint64_t size);
+IMPORT char* CALL __co_strcpy(char* dst, char const* src);
+IMPORT char* CALL __co_strncpy(char* dst, char const* src, uint64_t size);
+IMPORT char* CALL __co_strcat(char* dst, char const* src);
+IMPORT char* CALL __co_strncat(char* dst, char const* src, uint64_t size);
+IMPORT int64_t CALL __co_memcmp(void const* lhs, void const* rhs, uint64_t size);
+IMPORT void* CALL __co_memset(void* data, int c, uint64_t size);
+IMPORT void* CALL __co_memcpy(void* dst, void const* src, uint64_t size);
+IMPORT void* CALL __co_memmove(void* dst, void const* src, uint64_t size);
 #endif

--- a/std/c/string.cpp
+++ b/std/c/string.cpp
@@ -1,0 +1,13 @@
+#include "std.h"
+#include <cstring>
+IMPORT uint64_t CALL __co_strlen(char const* str) {return std::strlen(str);}
+IMPORT  int64_t CALL __co_strcmp(char const* lhs, char const* rhs) {return std::strcmp(lhs, rhs);}
+IMPORT  int64_t CALL __co_strncmp(char const* lhs, char const* rhs, uint64_t size) {return std::strncmp(lhs, rhs, size);}
+IMPORT char* CALL __co_strcpy(char* dst, char const* src) {return std::strcpy(dst, src);}
+IMPORT char* CALL __co_strncpy(char* dst, char const* src, uint64_t size) {return std::strncpy(dst, src, size);}
+IMPORT char* CALL __co_strcat(char* dst, char const* src) {return std::strcat(dst, src);}
+IMPORT char* CALL __co_strncat(char* dst, char const* src, uint64_t size) {return std::strncat(dst, src, size);}
+IMPORT int64_t CALL __co_memcmp(void const* lhs, void const* rhs, uint64_t size) {return std::memcmp(lhs, rhs);}
+IMPORT void* CALL __co_memset(void* data, int c, uint64_t size) {return std::memset(data, c, size);}
+IMPORT void* CALL __co_memcpy(void* dst, void const* src, uint64_t size) {return std::memcpy(dst, src, size);}
+IMPORT void* CALL __co_memmove(void* dst, void const* src, uint64_t size) {return std::memmove(dst, src, size);}


### PR DESCRIPTION
While the current C portion of the standard library has all of the necessary features to interface with the OS, features such as string operations, memory copying, moving, and comparison, and exiting early have to be implemented in Cobalt, which would be slower than the optimized libc solution.
