### PR TITLE
Add support for parsing functions

### DIFF
--- a/include/cobalt/ast/funcs.hpp
+++ b/include/cobalt/ast/funcs.hpp
@@ -22,27 +22,28 @@ namespace cobalt::ast {
     void print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const override;
   };
   struct cast_ast : ast_base {
-    type_ptr target;
+    sstring target;
     AST val;
-    cast_ast(location loc, type_ptr target, AST val) : ast_base(loc), target(target), CO_INIT(val) {}
+    cast_ast(location loc, sstring target, AST val) : ast_base(loc), target(target), CO_INIT(val) {}
     bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<cast_ast const*>(other)) return target == ptr->target && val == ptr->val; else return false;}
   private:
     typed_value codegen_impl(compile_context& ctx) const override;
     void print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const override;
   };
   struct call_ast : ast_base {
-    sstring name;
+    AST val;
     std::vector<AST> args;
-    call_ast(location loc, sstring name, std::vector<AST>&& args) : ast_base(loc), name(name), CO_INIT(args) {}
-    bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<call_ast const*>(other)) return name == ptr->name && args == ptr->args; else return false;}
+    call_ast(location loc, AST val, std::vector<AST>&& args) : ast_base(loc), CO_INIT(val), CO_INIT(args) {}
+    bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<call_ast const*>(other)) return val == ptr->val && args == ptr->args; else return false;}
   private:
     typed_value codegen_impl(compile_context& ctx) const override;
     void print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const override;
   };
   struct fndef_ast : ast_base {
-    sstring name;
-    std::vector<type_ptr> args;
-    fndef_ast(location loc, sstring name, std::vector<type_ptr>&& args) : ast_base(loc), name(name), CO_INIT(args) {}
+    sstring name, ret;
+    std::vector<std::pair<sstring, sstring>> args;
+    AST body;
+    fndef_ast(location loc, sstring name, sstring ret, std::vector<std::pair<sstring, sstring>>&& args, AST&& body) : ast_base(loc), name(name), ret(ret), CO_INIT(args), CO_INIT(body) {}
     bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<fndef_ast const*>(other)) return name == ptr->name && args == ptr->args; else return false;}
   private:
     typed_value codegen_impl(compile_context& ctx) const override;

--- a/src/cobalt/print-ast.cpp
+++ b/src/cobalt/print-ast.cpp
@@ -3,7 +3,7 @@ using namespace cobalt;
 // ast.hpp
 void cobalt::ast::ast_base::print_self(llvm::raw_ostream& os, llvm::Twine name) const {os << name + "\n";}
 void cobalt::ast::ast_base::print_node(llvm::raw_ostream& os, llvm::Twine prefix, AST const& ast, bool last) const {
-  os << prefix + (last ? "└── ": "├── ");
+  os << prefix + (last ? "└── " : "├── ");
   ast.print_impl(os, prefix + (last ? "    " : "│   "));
 }
 // flow.hpp
@@ -50,7 +50,7 @@ void cobalt::ast::for_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix)
 }
 // funcs.hpp
 void cobalt::ast::cast_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {
-  print_self(os, llvm::Twine("cast: ") + (target ? target->name() : "<error>"));
+  print_self(os, llvm::Twine("cast: ") + target);
   print_node(os, prefix, val, true);
 }
 void cobalt::ast::binop_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {
@@ -63,15 +63,20 @@ void cobalt::ast::unop_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix
   print_node(os, prefix, val, true);
 }
 void cobalt::ast::call_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {
-  print_self(os, llvm::Twine("call: ") + name);
+  print_self(os, "call");
+  print_node(os, prefix, val, args.empty());
   if (args.empty()) return;
   auto last = &args.back();
   for (auto const& ast : args) print_node(os, prefix, ast, &ast == last);
 }
 void cobalt::ast::fndef_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {
-  os << llvm::Twine("fndef: ") + name + ", args: ";
-  auto last = &args.back();
-  for (auto const& type : args) os << (&type == last ? llvm::Twine(type->name()) + "\n" : llvm::Twine(type->name()) + ", ");
+  auto sz = args.size();
+  if (sz) {
+    os << llvm::Twine("fndef: ") + name + ", return: " + ret + ", params: \n";
+    for (auto& [param, type] : args) os << prefix << "├── " << param << ": " << type << '\n';
+  }
+  else os << llvm::Twine("fndef: ") + name + ", no params\n";
+  print_node(os, prefix, body, true);
 }
 // literals.hpp
 void cobalt::ast::integer_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {


### PR DESCRIPTION
Functions can now be parsed. Along with this, the `cr` keyword has also been added, which will be used for coroutines later.
