### PR TITLE
Add parsing support for function calls and array subscriptions

### DIFF
--- a/include/cobalt/ast/funcs.hpp
+++ b/include/cobalt/ast/funcs.hpp
@@ -39,6 +39,15 @@ namespace cobalt::ast {
     typed_value codegen_impl(compile_context& ctx) const override;
     void print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const override;
   };
+  struct subscr_ast : ast_base {
+    AST val;
+    std::vector<AST> args;
+    subscr_ast(location loc, AST val, std::vector<AST>&& args) : ast_base(loc), CO_INIT(val), CO_INIT(args) {}
+    bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<call_ast const*>(other)) return val == ptr->val && args == ptr->args; else return false;}
+  private:
+    typed_value codegen_impl(compile_context& ctx) const override;
+    void print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const override;
+  };
   struct fndef_ast : ast_base {
     sstring name, ret;
     std::vector<std::pair<sstring, sstring>> args;

--- a/src/cobalt/codegen.cpp
+++ b/src/cobalt/codegen.cpp
@@ -11,6 +11,7 @@ typed_value cobalt::ast::for_ast::codegen_impl(compile_context& ctx) const {(voi
 typed_value cobalt::ast::cast_ast::codegen_impl(compile_context& ctx) const {(void)ctx; return nullval;}
 typed_value cobalt::ast::binop_ast::codegen_impl(compile_context& ctx) const {(void)ctx; return nullval;}
 typed_value cobalt::ast::unop_ast::codegen_impl(compile_context& ctx) const {(void)ctx; return nullval;}
+typed_value cobalt::ast::subscr_ast::codegen_impl(compile_context& ctx) const {(void)ctx; return nullval;}
 typed_value cobalt::ast::call_ast::codegen_impl(compile_context& ctx) const {(void)ctx; return nullval;}
 typed_value cobalt::ast::fndef_ast::codegen_impl(compile_context& ctx) const {(void)ctx; return nullval;}
 // literals.hpp

--- a/src/cobalt/print-ast.cpp
+++ b/src/cobalt/print-ast.cpp
@@ -69,6 +69,13 @@ void cobalt::ast::call_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix
   auto last = &args.back();
   for (auto const& ast : args) print_node(os, prefix, ast, &ast == last);
 }
+void cobalt::ast::subscr_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {
+  print_self(os, "subscript");
+  print_node(os, prefix, val, args.empty());
+  if (args.empty()) return;
+  auto last = &args.back();
+  for (auto const& ast : args) print_node(os, prefix, ast, &ast == last);
+}
 void cobalt::ast::fndef_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {
   auto sz = args.size();
   if (sz) {


### PR DESCRIPTION
This adds support for functions and arrays, which parse similarly.
Example code:
```
fn f(x: i32): i32 = x + 1;
fn main(): i32 = f(-1);
```