### PR TITLE
Add debug subcommand

### DIFF
--- a/src/co/main.cpp
+++ b/src/co/main.cpp
@@ -44,22 +44,22 @@ tokens are printed as file:line:col: data, where data will be printed as hex for
 constexpr char parse_help[] = R"(co parse file1, file2...
 -c                          interpret next argument as code to parse
 )";
-void pretty_print(cobalt::token const& tok) {
+void pretty_print(llvm::raw_ostream& os, cobalt::token const& tok) {
   constexpr char chars[] = "0123456789abcdef";
-  llvm::outs() << tok.loc << ":\t";
+  os << tok.loc << ":\t";
   if (tok.data.size()) {
     char c = tok.data.front();
     if (c >= '0' && c <= '9') {
-      llvm::outs() << c;
+      os << c;
       auto it = tok.data.begin();
-      llvm::outs() << ' ';
+      os << ' ';
       while (++it != tok.data.end()) {
-        llvm::outs() << chars[(unsigned char)(*it) >> 4] << chars[*it & 15];
+        os << chars[(unsigned char)(*it) >> 4] << chars[*it & 15];
       }
     }
-    else llvm::outs() << tok.data;
+    else os << tok.data;
   }
-  llvm::outs() << '\n';
+  os << '\n';
 }
 template <int code> int cleanup() {llvm::errs().flush(); return code;}
 int main(int argc, char** argv) {
@@ -113,7 +113,7 @@ co help [category]
           fail = true;
         }
       }
-      for (auto const& tok : toks) pretty_print(tok);
+      for (auto const& tok : toks) pretty_print(llvm::outs(), tok);
       fail |= handler.errors;
     }
     return fail;
@@ -142,6 +142,140 @@ co help [category]
       fail |= handler.errors;
     }
     return fail;
+  }
+  if (cmd == "debug") {
+    bool markdown = false;
+    std::string_view output = "";
+    std::string_view code = "";
+    bool code_set = false;
+    std::string_view source = "";
+    for (auto it = argv + 2; it != argv + argc; ++it) {
+      std::string_view flag = *it;
+      if (flag.front() == '-' && flag.size() != 1) {
+        flag.remove_prefix(1);
+        if (flag.front() == '-') {
+          flag.remove_prefix(1);
+          if (flag == "markdown") {
+            if (markdown) llvm::errs() << "reuse of --markdown flag\n";
+            else markdown = true;
+          }
+          else {
+            llvm::errs() << "unknown flag --" << flag << '\n';
+            return cleanup<1>();
+          }
+        }
+        for (char c : flag) switch (c) {
+          case 'c':
+            code_set = true;
+            if (++it == argv + argc) {
+              llvm::errs() << "unspecified input for -c flag\n";
+              return cleanup<1>();
+            }
+            code = *it;
+            break;
+          case 'm':
+            if (markdown) llvm::errs() << "reuse of -m flag\n";
+            else markdown = true;
+            break;
+          case 'o':
+            if (output.size()) {
+              llvm::errs() << "redefinition of output file\n";
+              return cleanup<1>();
+            }
+            if (++it == argv + argc) {
+              llvm::errs() << "unspecified output file\n";
+              return cleanup<1>();
+            }
+            output = *it;
+            break;
+          default:
+            llvm::outs() << "unknown flag -" << c;
+            return cleanup<1>();
+        }
+      }
+      else {
+        if (code_set) {
+          llvm::errs() << "redefiniton of input\n";
+          return cleanup<1>();
+        }
+        code_set = true;
+        source = flag;
+        auto f = llvm::MemoryBuffer::getFileOrSTDIN(flag, true, false);
+        if (!f) {
+          llvm::errs() << f.getError().message();
+          return cleanup<1>();
+        }
+        code = std::string_view{f.get()->getBuffer().data(), f.get()->getBufferSize()};
+      }
+    }
+    std::error_code ec;
+    llvm::raw_fd_ostream os({output.empty() ? (std::string(source.empty() ? "cmdline" : (source == "-" ? "stdin" : source)) + (markdown ? ".md" : ".out")) : output}, ec);
+    if (ec) {
+      llvm::errs() << ec.message() << '\n';
+      return cleanup<3>();
+    }
+    cobalt::flags_t flags;
+    cobalt::default_handler_t h;
+    flags.onerror = h;
+    std::size_t tok_warn, tok_err, ast_warn, ast_err, ll_warn, ll_err;
+    bool tok_crit, ast_crit, ll_crit;
+    std::string_view pretty_src = source.empty() ? "<command line>" : (source == "-" ? "<stdin>" : source);
+    auto toks = cobalt::tokenize(code, cobalt::sstring::get(pretty_src), flags);
+    tok_warn = std::exchange(h.warnings, 0);
+    tok_err  = std::exchange(h.errors, 0);
+    tok_crit = std::exchange(h.critical, false);
+    auto ast = cobalt::parse({toks.begin(), toks.end()}, flags);
+    ast_warn = std::exchange(h.warnings, 0);
+    ast_err  = std::exchange(h.errors, 0);
+    ast_crit = std::exchange(h.critical, false);
+    cobalt::compile_context ctx{std::string(pretty_src)};
+    ast(ctx);
+    ll_warn = h.warnings;
+    ll_err  = h.errors;
+    ll_crit = h.critical;
+    if (markdown) {
+      if (source.empty()) os << "# Original\nThis is the original source from the command line:\n```\n";
+      else if (source == "-") os << "# Original\nThis is the original source from the standard input:\n```\n";
+      else os << "# Original\nThis is the original source from `" << source << "`:\n```\n";
+      os << code;
+      os << "\n```\n# Tokens\nThese are the generated tokens:\n```\n";
+      for (auto const& tok : toks) pretty_print(os, tok);
+      os << "```\nThere were " << tok_warn << " warnings and " << tok_err << " errors.";
+      if (tok_crit) os << "\nThere was at least one critical error.\n";
+      else os << "\nThere were no critical errors.\n";
+      os << "\n# AST\nThis is the generated AST:\n```\n";
+      ast.print(os);
+      os << "```\nThere were " << ast_warn << " warnings and " << ast_err << " errors.";
+      if (ast_crit) os << "\nThere was at least one critical error.\n";
+      else os << "\nThere were no critical errors.\n";
+      os << "\n# LLVM IR\nThis is the generated IR:\n```\n";
+      os << *ctx.module;
+      os << "```\nThere were " << ll_warn << " warnings and " << ll_err << " errors.";
+      if (ll_crit) os << "\nThere was at least one critical error.";
+      else os << "\nThere were no critical errors.";
+    }
+    else {
+      if (source.empty()) os << "Original\nThis is the original source from the command line:\n\n";
+      else if (source == "-") os << "Original\nThis is the original source from the standard input:\n\n";
+      else os << "Original\nThis is the original source from `" << source << "`:\n\n";
+      os << code;
+      os << "\n\nTokens\nThese are the generated tokens:\n\n";
+      for (auto const& tok : toks) pretty_print(os, tok);
+      os << "\nThere were " << tok_warn << " warnings and " << tok_err << " errors.";
+      if (tok_crit) os << "\nThere was at least one critical error.\n";
+      else os << "\nThere were no critical errors.\n";
+      os << "\nAST\nThis is the generated AST:\n\n";
+      ast.print(os);
+      os << "\nThere were " << ast_warn << " warnings and " << ast_err << " errors.";
+      if (ast_crit) os << "\nThere was at least one critical error.\n";
+      else os << "\nThere were no critical errors.\n";
+      os << "\nLLVM IR\nThis is the generated IR:\n\n";
+      os << *ctx.module;
+      os << "\nThere were " << ll_warn << " warnings and " << ll_err << " errors.";
+      if (ll_crit) os << "\nThere was at least one critical error.";
+      else os << "\nThere were no critical errors.";
+    }
+    return cleanup<0>();
   }
   if (cmd == "build") {
     // TODO: add build command
@@ -253,7 +387,7 @@ co help [category]
     std::error_code ec;
     llvm::raw_fd_ostream os({output}, ec);
     if (ec) {
-      llvm::errs() << ec.message();
+      llvm::errs() << ec.message() << '\n';
       return cleanup<3>();
     }
     switch (output_type) {


### PR DESCRIPTION
The `co debug` subcommand generates a file containing the original file, generated tokens, generated AST, and generated IR.
Example usage: `co debug test.co`
Result (written to `test.co.out`):
```
Original
This is the original source from `test.co`:

module x {
	module y {
		import std.file.*;
	}
	let a = 1 + 2 * 3;
	let b = 2 ^^ 3 ^^ 4;
	let c : i8 = 5 * a;
}
fn main(): i32 = {
	import x.y.*;
	let io = stdout();
	io.println("Hello, World!");
	0
};

Tokens
These are the generated tokens:

test.co:1:1:	module
test.co:1:8:	x
test.co:1:10:	{
test.co:2:2:	module
test.co:2:9:	y
test.co:2:11:	{
test.co:3:3:	import
test.co:3:10:	std
test.co:3:13:	.
test.co:3:14:	file
test.co:3:18:	.
test.co:3:19:	*
test.co:3:20:	;
test.co:4:2:	}
test.co:5:2:	let
test.co:5:6:	a
test.co:5:8:	=
test.co:5:10:	0 010000000000000000
test.co:5:12:	+
test.co:5:14:	0 020000000000000000
test.co:5:16:	*
test.co:5:18:	0 030000000000000000
test.co:5:19:	;
test.co:6:2:	let
test.co:6:6:	b
test.co:6:8:	=
test.co:6:10:	0 020000000000000000
test.co:6:12:	^^
test.co:6:15:	0 030000000000000000
test.co:6:17:	^^
test.co:6:20:	0 040000000000000000
test.co:6:21:	;
test.co:7:2:	let
test.co:7:6:	c
test.co:7:8:	:
test.co:7:10:	i8
test.co:7:13:	=
test.co:7:15:	0 050000000000000000
test.co:7:17:	*
test.co:7:19:	a
test.co:7:20:	;
test.co:8:1:	}
test.co:9:1:	fn
test.co:9:4:	main
test.co:9:8:	(
test.co:9:9:	)
test.co:9:10:	:
test.co:9:12:	i32
test.co:9:16:	=
test.co:9:18:	{
test.co:10:2:	import
test.co:10:9:	x
test.co:10:10:	.
test.co:10:11:	y
test.co:10:12:	.
test.co:10:13:	*
test.co:10:14:	;
test.co:11:2:	let
test.co:11:6:	io
test.co:11:9:	=
test.co:11:11:	stdout
test.co:11:17:	(
test.co:11:18:	)
test.co:11:19:	;
test.co:12:2:	io
test.co:12:4:	.
test.co:12:5:	println
test.co:12:12:	(
test.co:12:13:	"Hello, World!
test.co:12:28:	)
test.co:12:29:	;
test.co:13:2:	0 000000000000000000
test.co:14:1:	}
test.co:14:2:	;

There were 0 warnings and 0 errors.
There were no critical errors.

AST
This is the generated AST:

top level
├── module x
│   ├── module y
│   │   └── import: std.file.*
│   ├── vardef: a
│   │   └── op: +
│   │       ├── int: 1
│   │       └── op: *
│   │           ├── int: 2
│   │           └── int: 3
│   ├── vardef: b
│   │   └── op: ^^
│   │       ├── op: ^^
│   │       │   ├── int: 2
│   │       │   └── int: 3
│   │       └── int: 4
│   └── vardef: c
│       └── cast: i8
│           └── op: *
│               ├── int: 5
│               └── varget: a
└── fndef: main, no params
    └── block
        ├── import: x.y.*
        ├── vardef: io
        │   └── varget: stdout()
        ├── varget: io.println("Hello, World!)
        └── int: 0

There were 0 warnings and 0 errors.
There were no critical errors.

LLVM IR
This is the generated IR:

; ModuleID = 'test.co'
source_filename = "test.co"

There were 0 warnings and 0 errors.
There were no critical errors.
```