### PR TITLE
Fix parsing of string and character literals

### DIFF
--- a/src/cobalt/parser.cpp
+++ b/src/cobalt/parser.cpp
@@ -140,6 +140,8 @@ AST parse_literals(span<token> code, flags_t flags) {
       }
       case '1':
         return AST::create<ast::float_ast>(code.front().loc, reinterpret_cast<float const&>(tok[1]), sstring::get(""));
+      case '\'':
+        return AST::create<ast::char_ast>(code.front().loc, std::string(tok.substr(1)), sstring::get(""));
       case '"':
         return AST::create<ast::string_ast>(code.front().loc, (llvm::Twine("\"") + tok.substr(1) + "\"").str(), sstring::get(""));
       default:

--- a/src/cobalt/parser.cpp
+++ b/src/cobalt/parser.cpp
@@ -143,7 +143,7 @@ AST parse_literals(span<token> code, flags_t flags) {
       case '\'':
         return AST::create<ast::char_ast>(code.front().loc, std::string(tok.substr(1)), sstring::get(""));
       case '"':
-        return AST::create<ast::string_ast>(code.front().loc, (llvm::Twine("\"") + tok.substr(1) + "\"").str(), sstring::get(""));
+        return AST::create<ast::string_ast>(code.front().loc, std::string(tok.substr(1)), sstring::get(""));
       default:
         return AST::create<ast::varget_ast>(code.front().loc, sstring::get(tok));
     }

--- a/src/cobalt/print-ast.cpp
+++ b/src/cobalt/print-ast.cpp
@@ -97,12 +97,12 @@ void cobalt::ast::float_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefi
   os << '\n';
 }
 void cobalt::ast::string_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {
-  os << "int: " << val;
+  os << "string: " << val;
   if (!suffix.empty()) os << ", suffix: " << suffix;
   os << '\n';
 }
 void cobalt::ast::char_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {
-  os << "int: " << val;
+  os << "char: " << val;
   if (!suffix.empty()) os << ", suffix: " << suffix;
   os << '\n';
 }


### PR DESCRIPTION
This fixes various problems in the parsing of string and character literals, including:
- Character literals not parsing
- String literals being parsed with an extra set of quotation marks
- String and character literals being printed with the `int:` label