### PR TITLE
Update type representation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ add_library(cobalt
   include/cobalt.hpp
     include/cobalt/ast.hpp include/cobalt/ast/ast.hpp include/cobalt/ast/flow.hpp include/cobalt/ast/funcs.hpp include/cobalt/ast/literals.hpp include/cobalt/ast/scope.hpp include/cobalt/ast/vars.hpp
     include/cobalt/support/location.hpp include/cobalt/support/sstring.hpp include/cobalt/support/functions.hpp include/cobalt/support/token.hpp
-    include/cobalt/types/types.hpp include/cobalt/types/numeric.hpp include/cobalt/types/pointers.hpp include/cobalt/types/structurals.hpp
+    include/cobalt/types.hpp include/cobalt/types/types.hpp include/cobalt/types/numeric.hpp include/cobalt/types/pointers.hpp include/cobalt/types/structurals.hpp
     include/cobalt/context.hpp include/cobalt/varmap.hpp include/cobalt/typed_value.hpp
   src/cobalt/tokenizer.cpp src/cobalt/macros.cpp src/cobalt/parser.cpp src/cobalt/print-ast.cpp src/cobalt/codegen.cpp)
 if(CMAKE_BUILD_TYPE STREQUAL Debug AND EXISTS "${PROJECT_SOURCE_DIR}/stacktrace.cpp")

--- a/include/cobalt/types.hpp
+++ b/include/cobalt/types.hpp
@@ -1,0 +1,7 @@
+#ifndef COBALT_TYPES_HPP
+#define COBALT_TYPES_HPP
+#include "cobalt/types/types.hpp"
+#include "cobalt/types/numeric.hpp"
+#include "cobalt/types/pointers.hpp"
+#include "cobalt/types/structurals.hpp"
+#endif

--- a/include/cobalt/types/numeric.hpp
+++ b/include/cobalt/types/numeric.hpp
@@ -24,7 +24,7 @@ namespace cobalt::types {
     static integer const* word(llvm::DataLayout const& layout) {return get(layout.getPointerSize() * 8, false);}
     static integer const* uword(llvm::DataLayout const& layout) {return get(layout.getPointerSize() * 8, true);}
   private:
-    integer(int nbits) : nbits(nbits) {}
+    integer(int nbits) : type_base(INTEGER), nbits(nbits) {}
     inline static std::unordered_map<int, std::unique_ptr<integer>> instances;
   };
   struct float16 : type_base {
@@ -34,7 +34,7 @@ namespace cobalt::types {
     llvm::Type* llvm_type(location, compile_context& ctx) const override {return llvm::Type::getHalfTy(*ctx.context);}
     static float16 const* get() {return &inst;}
   private:
-    float16() = default;
+    float16() : type_base(FLOAT) {}
     static float16 inst;
   };
   struct float32 : type_base {
@@ -44,7 +44,7 @@ namespace cobalt::types {
     llvm::Type* llvm_type(location, compile_context& ctx) const override {return llvm::Type::getFloatTy(*ctx.context);}
     static float32 const* get() {return &inst;}
   private:
-    float32() = default;
+    float32() : type_base(FLOAT) {}
     static float32 inst;
   };
   struct float64 : type_base {
@@ -54,7 +54,7 @@ namespace cobalt::types {
     llvm::Type* llvm_type(location, compile_context& ctx) const override {return llvm::Type::getDoubleTy(*ctx.context);}
     static float64 const* get() {return &inst;}
   private:
-    float64() = default;
+    float64() : type_base(FLOAT) {}
     static float64 inst;
   };
   struct float128 : type_base {
@@ -64,7 +64,7 @@ namespace cobalt::types {
     llvm::Type* llvm_type(location, compile_context& ctx) const override {return llvm::Type::getFP128Ty(*ctx.context);}
     static float128 const* get() {return &inst;}
   private:
-    float128() = default;
+    float128() : type_base(FLOAT) {}
     static float128 inst;
   };
   // silence errors about incomplete types

--- a/include/cobalt/types/pointers.hpp
+++ b/include/cobalt/types/pointers.hpp
@@ -9,6 +9,14 @@ namespace cobalt::types {
     std::size_t size() const override {return 8;} // TODO: support 32-bit platforms
     std::size_t align() const override {return 8;}
     llvm::Type* llvm_type(location loc, compile_context& ctx) const override {return llvm::PointerType::get(base->llvm_type(loc, ctx), 0);}
+    static pointer const* get(type_ptr base) {
+      auto it = instances.find(base);
+      if (it == instances.end()) it = instances.insert({base, COBALT_MAKE_UNIQUE(pointer, base)}).first;
+      return it->second.get();
+    }
+  private:
+    pointer(type_ptr base) : type_base(POINTER), base(base) {}
+    inline static std::unordered_map<type_ptr, std::unique_ptr<pointer>> instances;
   };
   struct reference : type_base {
     type_ptr base;
@@ -16,6 +24,14 @@ namespace cobalt::types {
     std::size_t size() const override {return 8;}
     std::size_t align() const override {return 8;}
     llvm::Type* llvm_type(location loc, compile_context& ctx) const override {return llvm::PointerType::get(base->llvm_type(loc, ctx), 0);}
+    static reference const* get(type_ptr base) {
+      auto it = instances.find(base);
+      if (it == instances.end()) it = instances.insert({base, COBALT_MAKE_UNIQUE(reference, base)}).first;
+      return it->second.get();
+    }
+  private:
+    reference(type_ptr base) : type_base(base->type), base(base) {}
+    inline static std::unordered_map<type_ptr, std::unique_ptr<reference>> instances;
   };
   struct borrow : type_base {
     type_ptr base;
@@ -23,6 +39,14 @@ namespace cobalt::types {
     std::size_t size() const override {return base->size();}
     std::size_t align() const override {return base->align();}
     llvm::Type* llvm_type(location loc, compile_context& ctx) const override {return base->llvm_type(loc, ctx);}
+    static borrow const* get(type_ptr base) {
+      auto it = instances.find(base);
+      if (it == instances.end()) it = instances.insert({base, COBALT_MAKE_UNIQUE(borrow, base)}).first;
+      return it->second.get();
+    }
+  private:
+    borrow(type_ptr base) : type_base(base->type), base(base) {}
+    inline static std::unordered_map<type_ptr, std::unique_ptr<borrow>> instances;
   };
 }
 #endif

--- a/include/cobalt/types/types.hpp
+++ b/include/cobalt/types/types.hpp
@@ -9,7 +9,9 @@ namespace cobalt {
   struct compile_context;
   namespace types {
     struct type_base {
-      type_base() = default;
+      enum type_t {INTEGER, FLOAT, POINTER, CUSTOM};
+      const type_t type;
+      type_base(type_t type) : type(type) {}
       type_base(type_base const&) = delete;
       type_base(type_base&&) = delete;
       virtual ~type_base() = 0;

--- a/src/cobalt/codegen.cpp
+++ b/src/cobalt/codegen.cpp
@@ -1,6 +1,7 @@
 #include "cobalt/ast.hpp"
 #include "cobalt/context.hpp"
 #include "cobalt/varmap.hpp"
+#include "cobalt/types.hpp"
 using namespace cobalt;
 // flow.hpp
 typed_value cobalt::ast::top_level_ast::codegen_impl(compile_context& ctx) const {


### PR DESCRIPTION
At various points during code generation, it is necessary to check the kind (integer, float, pointer, etc.) of a type, such as when implementing built-in operators. Since C++'s RTTI is slow, an enum is used instead.
