### PR TITLE
Update AOT option parsing for driver

### DIFF
--- a/src/co/main.cpp
+++ b/src/co/main.cpp
@@ -278,7 +278,8 @@ co help [category]
         llvm::WriteBitcodeToFile(*cobalt::global.module, os);
         break;
       default:
-
+        llvm::errs() << "only LLVM IR and bytecode outputs are currently supported\n";
+        return cleanup<1>();
         break;
     }
     // TODO: AOT compiler


### PR DESCRIPTION
Various changes have been made, including:
- The driver properly parses input and output files from the standard input.
- If there's an error opening the file, the file's name is printed with the error.
- Attempting to compile to native code gives an error instead of failing silently.
- The `-l` flag now checks the next option for the library name, similarly to the `-o` flag.