### PR TITLE
Add parser support for annotations

### DIFF
--- a/include/cobalt/ast/funcs.hpp
+++ b/include/cobalt/ast/funcs.hpp
@@ -52,7 +52,8 @@ namespace cobalt::ast {
     sstring name, ret;
     std::vector<std::pair<sstring, sstring>> args;
     AST body;
-    fndef_ast(location loc, sstring name, sstring ret, std::vector<std::pair<sstring, sstring>>&& args, AST&& body) : ast_base(loc), name(name), ret(ret), CO_INIT(args), CO_INIT(body) {}
+    std::vector<std::string> annotations;
+    fndef_ast(location loc, sstring name, sstring ret, std::vector<std::pair<sstring, sstring>>&& args, AST&& body, std::vector<std::string>&& annotations) : ast_base(loc), name(name), ret(ret), CO_INIT(args), CO_INIT(body), CO_INIT(annotations) {}
     bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<fndef_ast const*>(other)) return name == ptr->name && args == ptr->args; else return false;}
   private:
     typed_value codegen_impl(compile_context& ctx) const override;

--- a/include/cobalt/ast/vars.hpp
+++ b/include/cobalt/ast/vars.hpp
@@ -6,7 +6,8 @@ namespace cobalt {
     struct vardef_ast : ast_base {
       sstring name;
       AST val;
-      vardef_ast(location loc, sstring name, AST&& val) : ast_base(loc), name(name), CO_INIT(val) {}
+      std::vector<std::string> annotations = {};
+      vardef_ast(location loc, sstring name, AST&& val, std::vector<std::string>&& annotations = {}) : ast_base(loc), name(name), CO_INIT(val), CO_INIT(annotations) {}
       bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<vardef_ast const*>(other)) return name == ptr->name && val == ptr->val; else return false;}
     private: 
     typed_value codegen_impl(compile_context& ctx) const override;
@@ -15,7 +16,8 @@ namespace cobalt {
     struct mutdef_ast : ast_base {
       sstring name;
       AST val;
-      mutdef_ast(location loc, sstring name, AST&& val) : ast_base(loc), name(name), CO_INIT(val) {}
+      std::vector<std::string> annotations = {};
+      mutdef_ast(location loc, sstring name, AST&& val, std::vector<std::string>&& annotations = {}) : ast_base(loc), name(name), CO_INIT(val), CO_INIT(annotations) {}
       bool eq(ast_base const* other) const override {if (auto ptr = dynamic_cast<mutdef_ast const*>(other)) return name == ptr->name && val == ptr->val; else return false;}
     private: 
     typed_value codegen_impl(compile_context& ctx) const override;

--- a/src/cobalt/parser.cpp
+++ b/src/cobalt/parser.cpp
@@ -466,20 +466,34 @@ std::pair<AST, span<token>::iterator> parse_expr(span<token> code, flags_t flags
   return {parse_infix({code.begin(), it}, flags, &bin_ops[2]), it};
 }
 std::pair<AST, span<token>::iterator> parse_statement(span<token> code, flags_t flags) {
-#define UNSUPPORTED(TYPE) {flags.onerror(it->loc, TYPE " definitions are not currently supported", CRITICAL);}
+#define UNSUPPORTED(TYPE) {flags.onerror(it->loc, TYPE " definitions are not currently supported", CRITICAL); return {AST(nullptr), code.begin() + 1};}
   if (code.empty()) return {AST{nullptr}, code.end()};
   auto it = code.begin(), end = code.end();
   std::string_view tok = it->data;
+  std::vector<std::string> annotations;
   switch (tok.front()) {
     case ';': break;
+    case '@': annotations.push_back(std::string(tok.substr(1)));
     case 'c':
       if (tok == "cr") UNSUPPORTED("coroutine")
       else goto ST_DEFAULT;
       break;
     case 'm':
       if (tok == "module") {
+        annotations.clear();
         flags.onerror(it->loc, "module definitions are only allowed at the top-level scope", ERROR);
-        goto ST_DEFAULT;
+        if (++it == end) return {AST(nullptr), end};
+        tok = it->data;
+        if (tok == ";") return {AST(nullptr), ++it};
+        else if (tok == "{") {
+          std::size_t depth = 0;
+          while (++it != end && depth) switch (it->data.front()) {
+            case '{': ++depth; break;
+            case '}': --depth; break;
+          }
+          return {AST(nullptr), it};
+        }
+        else return {AST(nullptr), it};
       }
       else if (tok == "mut") {
         auto start = it->loc;
@@ -489,7 +503,7 @@ std::pair<AST, span<token>::iterator> parse_statement(span<token> code, flags_t 
           name = it++->data;
           bool to_skip = false;
           switch (name.front()) {
-            case '.': 
+            case '.':
               flags.onerror((it - 1)->loc, "variable paths are not allowed in local variables", ERROR);
               to_skip = true;
               break;
@@ -519,11 +533,11 @@ std::pair<AST, span<token>::iterator> parse_statement(span<token> code, flags_t 
           }
           switch (it->data.front()) {
             case ':': break;
-            case '.': 
+            case '.':
               to_skip = true;
               flags.onerror(it->loc, "variable paths are not allowed in local variables", ERROR);
               break;
-            case '=': 
+            case '=':
               if (it->data.size() != 1) {
                 to_skip = true;
                 flags.onerror(it->loc, "unexpected identifier in local variable definition", ERROR);
@@ -561,13 +575,13 @@ std::pair<AST, span<token>::iterator> parse_statement(span<token> code, flags_t 
           it = it3;
           val = AST::create<ast::cast_ast>(start, t, std::move(ast));
         }
-        return {AST::create<ast::mutdef_ast>(start, sstring::get(name), std::move(val)), it};
+        return {AST::create<ast::mutdef_ast>(start, sstring::get(name), std::move(val), std::move(annotations)), it};
       }
-      else if (tok == "mixin") UNSUPPORTED("mixin")
+      else if (tok == "mixin") {annotations.clear(); UNSUPPORTED("mixin")}
       else goto ST_DEFAULT;
       break;
     case 's':
-      if (tok == "struct") UNSUPPORTED("struct")
+      if (tok == "struct") {annotations.clear(); UNSUPPORTED("struct")}
       else goto ST_DEFAULT;
       break;
     case 'f':
@@ -576,7 +590,7 @@ std::pair<AST, span<token>::iterator> parse_statement(span<token> code, flags_t 
         std::string name = (++it)->data;
         bool to_skip = false;
         switch (name.front()) {
-          case '.': 
+          case '.':
             flags.onerror(start, "variable paths are not allowed in local function", ERROR);
             to_skip = true;
             break;
@@ -711,12 +725,12 @@ std::pair<AST, span<token>::iterator> parse_statement(span<token> code, flags_t 
           }
           if (it->data != "=") {
             flags.onerror(it->loc, "function must have a body", ERROR);
-            return {AST::create<ast::fndef_ast>(start, sstring::get(name), return_type, std::move(params), AST(nullptr)), it};
+            return {AST::create<ast::fndef_ast>(start, sstring::get(name), return_type, std::move(params), AST(nullptr), std::move(annotations)), it};
           }
           else {
             auto [ast, i] = parse_expr({it + 1, end}, flags);
             it = i;
-            return {AST::create<ast::fndef_ast>(start, sstring::get(name), return_type, std::move(params), std::move(ast)), it};
+            return {AST::create<ast::fndef_ast>(start, sstring::get(name), return_type, std::move(params), std::move(ast), std::move(annotations)), it};
           }
         }
       }
@@ -731,7 +745,7 @@ std::pair<AST, span<token>::iterator> parse_statement(span<token> code, flags_t 
           name = it++->data;
           bool to_skip = false;
           switch (name.front()) {
-            case '.': 
+            case '.':
               flags.onerror((it - 1)->loc, "variable paths are not allowed in local variables", ERROR);
               to_skip = true;
               break;
@@ -761,11 +775,11 @@ std::pair<AST, span<token>::iterator> parse_statement(span<token> code, flags_t 
           }
           switch (it->data.front()) {
             case ':': break;
-            case '.': 
+            case '.':
               to_skip = true;
               flags.onerror(it->loc, "variable paths are not allowed in local variables", ERROR);
               break;
-            case '=': 
+            case '=':
               if (it->data.size() != 1) {
                 to_skip = true;
                 flags.onerror(it->loc, "unexpected identifier in local variable definition", ERROR);
@@ -803,13 +817,14 @@ std::pair<AST, span<token>::iterator> parse_statement(span<token> code, flags_t 
           it = it3;
           val = AST::create<ast::cast_ast>(start, t, std::move(ast));
         }
-        return {AST::create<ast::vardef_ast>(start, sstring::get(name), std::move(val)), it};
+        return {AST::create<ast::vardef_ast>(start, sstring::get(name), std::move(val), std::move(annotations)), it};
       }
       else goto ST_DEFAULT;
       break;
     case 'i':
       if (tok == "import") {
         location start = it->loc;
+        if (annotations.size()) flags.onerror(start, "annotations cannot be applied to an import statement", ERROR);
         std::vector<AST> paths;
         for (auto& path : parse_paths(it, code.end(), flags)) paths.push_back(AST::create<ast::import_ast>(start, std::move(path)));
         return {paths.size() == 1 ? std::move(paths.front()) : AST::create<ast::group_ast>(start, std::move(paths)), it};
@@ -817,6 +832,7 @@ std::pair<AST, span<token>::iterator> parse_statement(span<token> code, flags_t 
       else goto ST_DEFAULT;
       break;
     default: ST_DEFAULT:
+      if (annotations.size()) flags.onerror(it->loc, "annotations cannot be applied to expressions", ERROR);
       return parse_expr({it, end}, flags, ";}");
   }
   return {AST(nullptr), it};
@@ -827,16 +843,22 @@ std::pair<std::vector<AST>, span<token>::iterator> parse_tl(span<token> code, fl
   if (code.empty()) return {std::vector<AST>{}, code.end()};
   std::vector<AST> tl_nodes;
   const auto end = code.end();
+  std::vector<std::string> annotations;
   for (auto it = code.begin(); it != end; ++it) {
     std::string_view tok = it->data;
     switch (tok.front()) {
-      case ';': break;
+      case ';': llvm::outs() << ";\n"; break;
+      case '@': annotations.push_back(std::string(tok.substr(1)));
       case 'c':
-        if (tok == "cr") UNSUPPORTED("coroutine")
+        if (tok == "cr") {annotations.clear(); UNSUPPORTED("coroutine")}
         else goto TL_DEFAULT;
         break;
       case 'm':
         if (tok == "module") {
+          if (annotations.size()) {
+            flags.onerror(it->loc, "annotations cannot be applied to a module", ERROR);
+            annotations.clear();
+          }
           auto start = it->loc;
           std::string module_path;
           uint8_t lwp = 2; // last was period; 0=false, 1=true, 2=start
@@ -981,13 +1003,13 @@ std::pair<std::vector<AST>, span<token>::iterator> parse_tl(span<token> code, fl
             it = it3;
             val = AST::create<ast::cast_ast>(start, t, std::move(ast));
           }
-          tl_nodes.push_back(AST::create<ast::mutdef_ast>(start, sstring::get(name), std::move(val)));
+          tl_nodes.push_back(AST::create<ast::mutdef_ast>(start, sstring::get(name), std::move(val), std::exchange(annotations, {})));
         }
-        else if (tok == "mixin") UNSUPPORTED("mixin")
+        else if (tok == "mixin") {annotations.clear(); UNSUPPORTED("mixin")}
         else goto TL_DEFAULT;
         break;
       case 's':
-        if (tok == "struct") UNSUPPORTED("struct")
+        if (tok == "struct") {annotations.clear(); UNSUPPORTED("struct")}
         else goto TL_DEFAULT;
         break;
       case 'f':
@@ -1128,7 +1150,7 @@ std::pair<std::vector<AST>, span<token>::iterator> parse_tl(span<token> code, fl
             else {
               auto [ast, i] = parse_expr({it + 1, end}, flags);
               it = i;
-              tl_nodes.push_back(AST::create<ast::fndef_ast>(start, sstring::get(name), return_type, std::move(params), std::move(ast)));
+              tl_nodes.push_back(AST::create<ast::fndef_ast>(start, sstring::get(name), return_type, std::move(params), std::move(ast), std::exchange(annotations, {})));
             }
           }
         }
@@ -1216,19 +1238,23 @@ std::pair<std::vector<AST>, span<token>::iterator> parse_tl(span<token> code, fl
             it = it3;
             val = AST::create<ast::cast_ast>(start, t, std::move(ast));
           }
-          tl_nodes.push_back(AST::create<ast::vardef_ast>(start, sstring::get(name), std::move(val)));
+          tl_nodes.push_back(AST::create<ast::vardef_ast>(start, sstring::get(name), std::move(val), std::exchange(annotations, {})));
         }
         else goto TL_DEFAULT;
         break;
       case 'i':
         if (tok == "import") {
+          if (annotations.size()) flags.onerror(it->loc, "annotations cannot be applied to an import statement", ERROR);
           location start = it->loc;
           for (auto& path : parse_paths(it, code.end(), flags)) tl_nodes.push_back(AST::create<ast::import_ast>(start, std::move(path)));
         }
         else goto TL_DEFAULT;
         break;
-      case '}': return {std::move(tl_nodes), it};
+      case '}':
+        if (annotations.size()) flags.onerror(it->loc, "annotations must have a target", ERROR);
+        return {std::move(tl_nodes), it};
       default: TL_DEFAULT:
+        annotations.clear();
         flags.onerror(it->loc, (llvm::Twine("invalid top-level token '") + it->data + "'").str(), ERROR);
     }
   }

--- a/src/cobalt/parser.cpp
+++ b/src/cobalt/parser.cpp
@@ -473,7 +473,7 @@ std::pair<AST, span<token>::iterator> parse_statement(span<token> code, flags_t 
   std::vector<std::string> annotations;
   switch (tok.front()) {
     case ';': break;
-    case '@': annotations.push_back(std::string(tok.substr(1)));
+    case '@': annotations.push_back(std::string(tok.substr(1))); break;
     case 'c':
       if (tok == "cr") UNSUPPORTED("coroutine")
       else goto ST_DEFAULT;
@@ -848,7 +848,7 @@ std::pair<std::vector<AST>, span<token>::iterator> parse_tl(span<token> code, fl
     std::string_view tok = it->data;
     switch (tok.front()) {
       case ';': llvm::outs() << ";\n"; break;
-      case '@': annotations.push_back(std::string(tok.substr(1)));
+      case '@': annotations.push_back(std::string(tok.substr(1))); break;
       case 'c':
         if (tok == "cr") {annotations.clear(); UNSUPPORTED("coroutine")}
         else goto TL_DEFAULT;

--- a/src/cobalt/print-ast.cpp
+++ b/src/cobalt/print-ast.cpp
@@ -80,9 +80,10 @@ void cobalt::ast::fndef_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefi
   auto sz = args.size();
   if (sz) {
     os << llvm::Twine("fndef: ") + name + ", return: " + ret + ", params: \n";
-    for (auto& [param, type] : args) os << prefix << "├── " << param << ": " << type << '\n';
+    for (auto const& [param, type] : args) os << prefix << "├── " << param << ": " << type << '\n';
   }
   else os << llvm::Twine("fndef: ") + name + ", no params\n";
+  for (auto const& ann : annotations) os << prefix << "├── @" << ann << '\n';
   print_node(os, prefix, body, true);
 }
 // literals.hpp
@@ -132,10 +133,12 @@ void cobalt::ast::import_ast::print_impl(llvm::raw_ostream& os, llvm::Twine pref
 // vars.hpp
 void cobalt::ast::vardef_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {
   print_self(os, llvm::Twine("vardef: ") + name);
+  for (auto const& ann : annotations) os << prefix << "├── @" << ann << '\n';
   print_node(os, prefix, val, true);
 }
 void cobalt::ast::mutdef_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {
   print_self(os, llvm::Twine("mutdef: ") + name);
+  for (auto const& ann : annotations) os << prefix << "├── @" << ann << '\n';
   print_node(os, prefix, val, true);
 }
 void cobalt::ast::varget_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {

--- a/src/cobalt/tokenizer.cpp
+++ b/src/cobalt/tokenizer.cpp
@@ -474,6 +474,7 @@ template <class I> std::optional<std::string> parse_macro(I& it, I end, macro_ma
       case '~':
       case '|':
       case '!':
+      case '@':
       case '\\':
 #pragma endregion
         estate = WS;
@@ -485,7 +486,10 @@ template <class I> std::optional<std::string> parse_macro(I& it, I end, macro_ma
     step(c);
   }
   if (estate == BAD) {
-    if (it == end) estate = WS;
+    if (it == end) {
+      estate = WS;
+      ++it;
+    }
     else flags.onerror(loc, "invalid UTF-8 character", CRITICAL);
   }
   std::string_view macro_id;
@@ -542,6 +546,10 @@ template <class I> std::optional<std::string> parse_macro(I& it, I end, macro_ma
     args.append(start, it - 1);
   }
   else macro_id = std::string_view{start, --it};
+  if (macro_id.empty()) {
+    flags.onerror(loc, "macro name cannot be empty", ERROR);
+    return "";
+  }
   if (macro_id == "define") { // @define needs to be specially defined because it adds a macro
     flags.onerror(loc, "macro definition is not yet supported", CRITICAL);
     return std::nullopt;


### PR DESCRIPTION
Annotations are prefixed with an `@` and modify the behavior of a variable or function. Parsing support for them is added in this commit, but code generation still needs to be implemented.
Example:
```
@weak let x = 15;
@alias @noreturn fn exit(code: i32): void = 0;
```