### PR TITLE
Add compatibility with C++ 17 compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 
 project(Cobalt LANGUAGES C CXX)
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 execute_process(OUTPUT_VARIABLE LLVM_FLAGS COMMAND llvm-config --cppflags --ldflags --libs)

--- a/src/cobalt/tokenizer.cpp
+++ b/src/cobalt/tokenizer.cpp
@@ -490,7 +490,7 @@ template <class I> std::optional<std::string> parse_macro(I& it, I end, macro_ma
   std::string_view macro_id;
   std::string args;
   if (estate == PAREN) {
-    macro_id = std::string_view{start, it - 1};
+    macro_id = std::string_view{start, static_cast<std::size_t>(it - start) + 1};
     start = it;
     std::size_t depth = 1;
     while (depth && advance(it, end, c)) {
@@ -540,7 +540,7 @@ template <class I> std::optional<std::string> parse_macro(I& it, I end, macro_ma
     }
     args.append(start, it - 1);
   }
-  else macro_id = std::string_view{start, --it};
+  else macro_id = std::string_view{start, static_cast<std::size_t>(--it - start)};
   if (macro_id == "define") { // @define needs to be specially defined because it adds a macro
     flags.onerror(loc, "macro definition is not yet supported", CRITICAL);
     return std::nullopt;
@@ -988,7 +988,7 @@ std::vector<token> cobalt::tokenize(std::string_view code, location loc, flags_t
               return out;
             }
             auto it2 = code.begin() + idx;
-            std::string_view comment(it, it2);
+            std::string_view comment(it, it2 - it);
             it = it2 + count + 1;
             it2 = comment.begin();
             while (advance(it2, comment.end(), c)) step(c);

--- a/src/cobalt/tokenizer.cpp
+++ b/src/cobalt/tokenizer.cpp
@@ -1,6 +1,5 @@
 #include "cobalt/tokenizer.hpp"
 #include <cmath>
-#include <numbers>
 #include <optional>
 #include <llvm/ADT/APInt.h>
 #if __cplusplus >= 202002
@@ -125,7 +124,7 @@ static bool is_hex(char32_t c) {
 }
 template <class I> static std::string parse_num(I& it, I end, bound_handler const& onerror, borrow_function<char32_t(char32_t)> step) {
   uint32_t decimal_places = 0;
-  constexpr double log2_10 = std::numbers::ln10_v<double> / std::numbers::ln2_v<double>;
+  constexpr double log2_10 = 3.32192809;
   llvm::APInt int_part;
   double float_part = 0;
   double bits = 0;


### PR DESCRIPTION
The following changes have been made to allow builds using C++ 17:
- Removed `<numbers>` dependency in `tokenizer.cpp`
- Changed `CMAKE_CXX_STANDARD` to 17
- Removed uses of C++ 20 constructor of string views in `tokenizer.cpp`
