### PR TITLE
Fix parsing of floating-point tokens

### DIFF
--- a/src/cobalt/parser.cpp
+++ b/src/cobalt/parser.cpp
@@ -139,7 +139,7 @@ AST parse_literals(span<token> code, flags_t flags) {
         return AST::create<ast::integer_ast>(code.front().loc, llvm::APInt(words.size() * 64, words), sstring::get(""));
       }
       case '1':
-        return AST::create<ast::float_ast>(code.front().loc, reinterpret_cast<float const&>(tok[1]), sstring::get(""));
+        return AST::create<ast::float_ast>(code.front().loc, reinterpret_cast<double const&>(tok[1]), sstring::get(""));
       case '\'':
         return AST::create<ast::char_ast>(code.front().loc, std::string(tok.substr(1)), sstring::get(""));
       case '"':

--- a/src/cobalt/tokenizer.cpp
+++ b/src/cobalt/tokenizer.cpp
@@ -396,9 +396,9 @@ template <class I> static std::string parse_num(I& it, I end, bound_handler cons
   std::string out;
   if (decimal_places) {
     float_part += int_part.trunc(llvm::APInt::APINT_WORD_SIZE).getZExtValue();
-    out.resize(sizeof(double) + 2);
+    out.resize(sizeof(double) + 1);
     out[0] = '1';
-    std::memcpy(out.data() + 2, &float_part, sizeof(double));
+    std::memcpy(out.data() + 1, &float_part, sizeof(double));
   }
   else {
     out.resize(int_part.getNumWords() * llvm::APInt::APINT_WORD_SIZE + 2);


### PR DESCRIPTION
When a floating-point literal is converted to a token, it is stored natively as a `double`. When parsed into an AST node, it was previously not only read as a `float`, but also read from the wrong location. This is now fixed.