### PR TITLE
Improve support for C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 
 project(Cobalt LANGUAGES C CXX)
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_STANDARD 20)
 
 execute_process(OUTPUT_VARIABLE LLVM_FLAGS COMMAND llvm-config --cppflags --ldflags --libs)
 string(STRIP "${LLVM_FLAGS}" LLVM_FLAGS)

--- a/src/cobalt/tokenizer.cpp
+++ b/src/cobalt/tokenizer.cpp
@@ -10,7 +10,10 @@
 #else
 static unsigned char countl0(unsigned char c) {
   unsigned char out = 8;
-  while (c && out) c >>= 1;
+  while (c && out) {
+    c >>= 1;
+    --out;
+  }
   return out;
 }
 static unsigned char countl1(unsigned char c) {return countl0(~c);}


### PR DESCRIPTION
This should be the last PR for C++17 support. The following fixes are made:
- The `countl0` function in `tokenizer.cpp` unconditionally returned 8, which is now fixed
- `CMAKE_CXX_STANDARD_REQUIRED` is now disabled, allowing for C++20 builds if available
