### PR TITLE
Fix annotation and macro parsing

### DIFF
--- a/src/cobalt/tokenizer.cpp
+++ b/src/cobalt/tokenizer.cpp
@@ -497,7 +497,7 @@ template <class I> std::optional<std::string> parse_macro(I& it, I end, macro_ma
   std::string_view macro_id;
   std::string args;
   if (estate == PAREN) {
-    macro_id = std::string_view{start, static_cast<std::size_t>(it - start) + 1};
+    macro_id = std::string_view{start, static_cast<std::size_t>(it - start) - 1};
     start = it;
     std::size_t depth = 1;
     while (depth && advance(it, end, c)) {


### PR DESCRIPTION
The `std::string_view` constructor that takes two iterators was introduced in C++20, so it had to be changed to use the C++17 constructor taking the start and size. This change is now fixed, so macro parsing works.
Before:
`@test(a)` becomes `@test(a(a)` after tokenization
After:
`@test(a)` stays the same