### PR TITLE
Fix multicharacter operators

### DIFF
--- a/src/cobalt/tokenizer.cpp
+++ b/src/cobalt/tokenizer.cpp
@@ -1239,12 +1239,12 @@ std::vector<token> cobalt::tokenize(std::string_view code, location loc, flags_t
         case '>': {
           topb = true;
           char c2 = char((signed char)c);
-          if (out.size() && out.back().data == std::string_view{&c2, 1}) out.back().data.push_back(c2);
+          if (out.size() && out.back().data == std::string_view{&c2, 1} && out.back().data.back() == *(it - 2)) out.back().data.push_back(c2);
           else out.push_back({loc, {c2}});
         } break;
         case '=':
           topb = true;
-          if (out.size()) {
+          if (out.size() && out.back().data.back() == *(it - 2)) {
             if (out.back().data.size() == 1) switch (out.back().data.front()) {
               case '+':
               case '-':


### PR DESCRIPTION
The tokenizer would unconditionally merge two symbols that form a multicharacter operator, regardless of whether they are next to each other or not. This behvior has been fixed.
For example, the expression `a - -b`, which negates `b` and subtracts it from `a`, is interpreted as `a --b`, which is a syntax error.
Along with that, most instances of type literals are followed by an `=`, so having a `*` or `&` suffix in a type is an issue if it merges with the following `=`.