### PR TITLE
Add null type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,9 +16,9 @@ add_link_options(${LINK_DIR} ${LLVM_LIB})
 include_directories(include)
 add_library(cobalt
   include/cobalt.hpp
-    include/cobalt/ast.hpp include/cobalt/ast/ast.hpp include/cobalt/ast/flow.hpp include/cobalt/ast/funcs.hpp include/cobalt/ast/literals.hpp include/cobalt/ast/scope.hpp include/cobalt/ast/vars.hpp
+    include/cobalt/ast.hpp include/cobalt/ast/ast.hpp include/cobalt/ast/flow.hpp include/cobalt/ast/funcs.hpp include/cobalt/ast/keyvals.hpp include/cobalt/ast/literals.hpp include/cobalt/ast/scope.hpp include/cobalt/ast/vars.hpp
     include/cobalt/support/location.hpp include/cobalt/support/sstring.hpp include/cobalt/support/functions.hpp include/cobalt/support/token.hpp
-    include/cobalt/types.hpp include/cobalt/types/types.hpp include/cobalt/types/numeric.hpp include/cobalt/types/pointers.hpp include/cobalt/types/structurals.hpp include/cobalt/types/functions.hpp
+    include/cobalt/types.hpp include/cobalt/types/types.hpp include/cobalt/types/null.hpp include/cobalt/types/numeric.hpp include/cobalt/types/pointers.hpp include/cobalt/types/structurals.hpp include/cobalt/types/functions.hpp
     include/cobalt/context.hpp include/cobalt/varmap.hpp include/cobalt/typed_value.hpp
   src/cobalt/tokenizer.cpp src/cobalt/macros.cpp src/cobalt/parser.cpp src/cobalt/print-ast.cpp src/cobalt/ast-type.cpp src/cobalt/codegen.cpp)
 if(CMAKE_BUILD_TYPE STREQUAL Debug AND EXISTS "${PROJECT_SOURCE_DIR}/stacktrace.cpp")

--- a/include/cobalt/ast.hpp
+++ b/include/cobalt/ast.hpp
@@ -3,6 +3,7 @@
 #include "cobalt/ast/ast.hpp"
 #include "cobalt/ast/flow.hpp"
 #include "cobalt/ast/funcs.hpp"
+#include "cobalt/ast/keyvals.hpp"
 #include "cobalt/ast/literals.hpp"
 #include "cobalt/ast/scope.hpp"
 #include "cobalt/ast/vars.hpp"

--- a/include/cobalt/ast/keyvals.hpp
+++ b/include/cobalt/ast/keyvals.hpp
@@ -1,0 +1,15 @@
+#ifndef COBALT_AST_KEYVALS_HPP
+#define COBALT_AST_KEYVALS_HPP
+#include "cobalt/ast/ast.hpp"
+namespace cobalt::ast {
+  struct null_ast : ast_base {
+    null_ast(location loc) : ast_base(loc) {}
+    bool is_const() const noexcept override {return true;}
+    bool eq(ast_base const* other) const override {return typeid(other) == typeid(null_ast const*);}
+    typed_value codegen(compile_context& ctx = global) const override;
+    type_ptr type(base_context& ctx = global) const override;
+  private:
+    void print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const override;
+  };
+}
+#endif

--- a/include/cobalt/types.hpp
+++ b/include/cobalt/types.hpp
@@ -2,6 +2,7 @@
 #define COBALT_TYPES_HPP
 #include "cobalt/types/types.hpp"
 #include "cobalt/types/functions.hpp"
+#include "cobalt/types/null.hpp"
 #include "cobalt/types/numeric.hpp"
 #include "cobalt/types/pointers.hpp"
 #include "cobalt/types/structurals.hpp"

--- a/include/cobalt/types/functions.hpp
+++ b/include/cobalt/types/functions.hpp
@@ -1,0 +1,57 @@
+#ifndef COBALT_TYPES_FUNCTIONS_HPP
+#define COBALT_TYPES_FUNCTIONS_HPP
+namespace cobalt::types {
+  namespace {
+    struct fn_hash {
+      std::size_t operator()(std::vector<type_ptr> const& val) const {
+        std::size_t out = 0;
+        for (type_ptr ptr : val) out ^= (uintptr_t)ptr + 0x9e3779b9 + (out << 6) + (out >> 2);
+        return out;
+      }
+    };
+    struct fn_eq {
+      bool operator()(std::vector<type_ptr> const& lhs, std::vector<type_ptr> const& rhs) const {
+        if (lhs.size() != rhs.size()) return false;
+        return !std::memcmp(lhs.data(), rhs.data(), lhs.size() * sizeof(void*));
+      }
+    };
+  }
+  struct function : type_base {
+    type_ptr ret;
+    std::vector<type_ptr> args;
+    sstring name() const override {
+      std::string out{ret->name()};
+      out += '(';
+      for (auto arg : args) {
+        out += arg->name();
+        out += ", ";
+      }
+      if (args.empty()) out += ")";
+      else {
+        out.pop_back();
+        out.back() = ')';
+      }
+      return sstring::get(out);
+    }
+    std::size_t size() const override {return 0;}
+    std::size_t align() const override {return 1;}
+    llvm::Type* llvm_type(location loc, compile_context& ctx) const override {
+      auto r = ret->llvm_type(loc, ctx);
+      std::vector<llvm::Type*> as(args.size());
+      for (std::size_t i = 0; i < args.size(); ++i) as[i] = args[i]->llvm_type(loc, ctx);
+      return llvm::FunctionType::get(r, as, false);
+    }
+    static function const* get(type_ptr ret, std::vector<type_ptr>&& args) {
+      std::vector<type_ptr> lookup(args.size() + 1);
+      lookup[0] = ret;
+      std::memcpy(lookup.data() + 1, args.data(), args.size() * sizeof(type_ptr));
+      auto it = instances.find(lookup);
+      if (it == instances.end()) it = instances.insert({std::move(lookup), COBALT_MAKE_UNIQUE(function, ret, std::move(args))}).first;
+      return it->second.get();
+    }
+  private:
+    function(type_ptr ret, std::vector<type_ptr>&& args) : type_base(FUNCTION), ret(ret), CO_INIT(args) {}
+    inline static std::unordered_map<std::vector<type_ptr>, std::unique_ptr<function>, fn_hash, fn_eq> instances;
+  };
+}
+#endif

--- a/include/cobalt/types/null.hpp
+++ b/include/cobalt/types/null.hpp
@@ -1,0 +1,18 @@
+#ifndef COBALT_TYPES_NULL_HPP
+#define COBALT_TYPES_NULL_HPP
+#include "cobalt/types/types.hpp"
+namespace cobalt::types {
+  struct null : type_base {
+    sstring name() const override {return name_;}
+    std::size_t size() const override {return 0;}
+    std::size_t align() const override {return 1;}
+    llvm::Type* llvm_type(location loc, compile_context& ctx) const override {return llvm::Type::getVoidTy(*ctx.context);}
+    static null const* get() {return &inst;}
+  private:
+    null() : type_base(NULLTYPE) {}
+    const inline static sstring name_ = sstring::get("null");
+    const static null inst;
+  };
+  const inline null null::inst;
+}
+#endif

--- a/include/cobalt/types/numeric.hpp
+++ b/include/cobalt/types/numeric.hpp
@@ -29,49 +29,52 @@ namespace cobalt::types {
     inline static std::unordered_map<int, std::unique_ptr<integer>> instances;
   };
   struct float16 : type_base {
-    sstring name() const override {return sstring::get("f16");}
+    sstring name() const override {return name_;}
     std::size_t size() const override {return 2;}
     std::size_t align() const override {return 2;}
     llvm::Type* llvm_type(location, compile_context& ctx) const override {return llvm::Type::getHalfTy(*ctx.context);}
     static float16 const* get() {return &inst;}
   private:
     float16() : type_base(FLOAT) {}
-    static float16 inst;
+    const inline static sstring name_ = sstring::get("f16");
+    const static float16 inst;
   };
   struct float32 : type_base {
-    sstring name() const override {return sstring::get("f32");}
+    sstring name() const override {return name_;}
     std::size_t size() const override {return 4;}
     std::size_t align() const override {return 4;}
     llvm::Type* llvm_type(location, compile_context& ctx) const override {return llvm::Type::getFloatTy(*ctx.context);}
     static float32 const* get() {return &inst;}
   private:
     float32() : type_base(FLOAT) {}
-    static float32 inst;
+    const inline static sstring name_ = sstring::get("f32");
+    const static float32 inst;
   };
   struct float64 : type_base {
-    sstring name() const override {return sstring::get("f64");}
+    sstring name() const override {return name_;}
     std::size_t size() const override {return 8;}
     std::size_t align() const override {return 8;}
     llvm::Type* llvm_type(location, compile_context& ctx) const override {return llvm::Type::getDoubleTy(*ctx.context);}
     static float64 const* get() {return &inst;}
   private:
     float64() : type_base(FLOAT) {}
-    static float64 inst;
+    const inline static sstring name_ = sstring::get("f64");
+    const static float64 inst;
   };
   struct float128 : type_base {
-    sstring name() const override {return sstring::get("f128");}
+    sstring name() const override {return name_;}
     std::size_t size() const override {return 16;}
     std::size_t align() const override {return 8;}
     llvm::Type* llvm_type(location, compile_context& ctx) const override {return llvm::Type::getFP128Ty(*ctx.context);}
     static float128 const* get() {return &inst;}
   private:
     float128() : type_base(FLOAT) {}
-    static float128 inst;
+    const inline static sstring name_ = sstring::get("f128");
+    const static float128 inst;
   };
-  // silence errors about incomplete types
-  inline float16 float16::inst;
-  inline float32 float32::inst;
-  inline float64 float64::inst;
-  inline float128 float128::inst;
+  const inline float16 float16::inst;
+  const inline float32 float32::inst;
+  const inline float64 float64::inst;
+  const inline float128 float128::inst;
 }
 #endif

--- a/include/cobalt/types/pointers.hpp
+++ b/include/cobalt/types/pointers.hpp
@@ -10,7 +10,7 @@ namespace cobalt::types {
     sstring name() const override {return sstring::get(base->name() + "*");}
     std::size_t size() const override {return 8;} // TODO: support 32-bit platforms
     std::size_t align() const override {return 8;}
-    llvm::Type* llvm_type(location loc, compile_context& ctx) const override {return llvm::ArrayType::get(base->llvm_type(loc, ctx), 0);}
+    llvm::Type* llvm_type(location loc, compile_context& ctx) const override {return llvm::PointerType::get(base->llvm_type(loc, ctx), 0);}
     static pointer const* get(type_ptr base) {
       auto it = instances.find(base);
       if (it == instances.end()) it = instances.insert({base, COBALT_MAKE_UNIQUE(pointer, base)}).first;

--- a/include/cobalt/types/types.hpp
+++ b/include/cobalt/types/types.hpp
@@ -10,7 +10,7 @@ namespace cobalt {
   struct compile_context;
   namespace types {
     struct type_base {
-      enum kind_t {INTEGER, FLOAT, POINTER, REFERENCE, FUNCTION, CUSTOM};
+      enum kind_t {INTEGER, FLOAT, POINTER, REFERENCE, FUNCTION, NULLTYPE, CUSTOM};
       const kind_t kind;
       type_base(kind_t kind) : kind(kind) {}
       type_base(type_base const&) = delete;

--- a/src/cobalt/codegen.cpp
+++ b/src/cobalt/codegen.cpp
@@ -4,7 +4,7 @@
 #include "cobalt/types.hpp"
 using namespace cobalt;
 using enum types::type_base::kind_t;
-const static auto f16 = sstring::get("f16"), f32 = sstring::get("f32"), f64 = sstring::get("f64"), f128 = sstring::get("f128"), isize = sstring::get("isize"), usize = sstring::get("usize"), bool_ = sstring::get("bool");
+const static auto f16 = sstring::get("f16"), f32 = sstring::get("f32"), f64 = sstring::get("f64"), f128 = sstring::get("f128"), isize = sstring::get("isize"), usize = sstring::get("usize"), bool_ = sstring::get("bool"), null = sstring::get("null");
 static type_ptr parse_type(sstring str) {
   if (str.empty()) return nullptr;
   switch (str.back()) {
@@ -13,6 +13,7 @@ static type_ptr parse_type(sstring str) {
     case '^': return types::borrow::get(parse_type(sstring::get(str.substr(0, str.size() - 1))));
   }
   if (str == bool_) return types::integer::get(1);
+  if (str == null) return types::null::get();
   switch (str.front()) {
     case 'i':
       if (str == isize) return types::integer::get(sizeof(void*) * 8, false);
@@ -112,6 +113,7 @@ static llvm::Value* impl_convert(llvm::Value* v, type_ptr t1, type_ptr t2, locat
       case POINTER: return nullptr;
       case REFERENCE: return nullptr;
       case FUNCTION: return nullptr;
+      case NULLTYPE: return nullptr;
       case CUSTOM: return nullptr;
     }
     case FLOAT: switch (t2->kind) {
@@ -125,6 +127,7 @@ static llvm::Value* impl_convert(llvm::Value* v, type_ptr t1, type_ptr t2, locat
       case POINTER: return nullptr;
       case REFERENCE: return nullptr;
       case FUNCTION: return nullptr;
+      case NULLTYPE: return nullptr;
       case CUSTOM: return nullptr;
     }
     case POINTER: return nullptr;
@@ -132,6 +135,7 @@ static llvm::Value* impl_convert(llvm::Value* v, type_ptr t1, type_ptr t2, locat
       auto t = static_cast<types::reference const*>(t1)->base;
       return impl_convert(ctx.builder.CreateLoad(t->llvm_type(loc, ctx), v), t, t2, loc, ctx);
     }
+    case NULLTYPE: return nullptr;
     case FUNCTION: return nullptr;
     case CUSTOM: return nullptr;
   }
@@ -173,6 +177,7 @@ static llvm::Value* expl_convert(llvm::Value* v, type_ptr t1, type_ptr t2, locat
       case POINTER: return ctx.builder.CreateIntToPtr(v, t2->llvm_type(loc, ctx));
       case REFERENCE: return nullptr;
       case FUNCTION: return nullptr;
+      case NULLTYPE: return nullptr;
       case CUSTOM: return nullptr;
     }
     case FLOAT: switch (t2->kind) {
@@ -188,6 +193,7 @@ static llvm::Value* expl_convert(llvm::Value* v, type_ptr t1, type_ptr t2, locat
       case POINTER: return nullptr;
       case REFERENCE: return nullptr;
       case FUNCTION: return nullptr;
+      case NULLTYPE: return nullptr;
       case CUSTOM: return nullptr;
     }
     case POINTER: switch (t2->kind) {
@@ -198,18 +204,20 @@ static llvm::Value* expl_convert(llvm::Value* v, type_ptr t1, type_ptr t2, locat
       case POINTER: return ctx.builder.CreateBitCast(v, t2->llvm_type(loc, ctx));
       case REFERENCE: return nullptr;
       case FUNCTION: return nullptr;
+      case NULLTYPE: return nullptr;
       case CUSTOM: return nullptr;
     }
     case REFERENCE: {
       auto t = static_cast<types::reference const*>(t1)->base;
-      return impl_convert(ctx.builder.CreateLoad(t->llvm_type(loc, ctx), v), t, t2, loc, ctx);
+      return expl_convert(ctx.builder.CreateLoad(t->llvm_type(loc, ctx), v), t, t2, loc, ctx);
     }
+    case NULLTYPE: return nullptr;
     case FUNCTION: return nullptr;
     case CUSTOM: return nullptr;
   }
 }
 static typed_value unary_op(typed_value tv, std::string_view op, location loc, compile_context& ctx) {
-  if (!(tv.value && tv.type)) return nullval;
+  if (!tv.type) return nullval;
   switch (tv.type->kind) {
     case INTEGER:
       if (op == "+") return tv;
@@ -290,6 +298,7 @@ static typed_value unary_op(typed_value tv, std::string_view op, location loc, c
           break;
         case REFERENCE: break;
         case FUNCTION: break;
+        case NULLTYPE: break;
         case CUSTOM: break;
       }
       return unary_op({ctx.builder.CreateLoad(t->llvm_type(loc, ctx), tv.value), t}, op, loc, ctx);
@@ -297,6 +306,7 @@ static typed_value unary_op(typed_value tv, std::string_view op, location loc, c
     case FUNCTION:
       if (op == "&") return {ctx.builder.CreateBitCast(tv.value, llvm::Type::getInt8PtrTy(*ctx.context)), types::pointer::get(tv.type)};
       return nullval;
+    case NULLTYPE: return nullval;
     case CUSTOM: return nullval;
   }
 }
@@ -459,6 +469,7 @@ static typed_value binary_op(typed_value lhs, typed_value rhs, std::string_view 
         return binary_op(lhs, {ctx.builder.CreateLoad(t->llvm_type(loc, ctx), rhs.value), t}, op, loc, ctx);
       }
       case FUNCTION: return nullval;
+      case NULLTYPE: return nullval;
       case CUSTOM: return nullval;
     }
     case FLOAT: switch (rhs.type->kind) {
@@ -522,6 +533,7 @@ static typed_value binary_op(typed_value lhs, typed_value rhs, std::string_view 
         return binary_op(lhs, {ctx.builder.CreateLoad(t->llvm_type(loc, ctx), rhs.value), t}, op, loc, ctx);
       }
       case FUNCTION: return nullval;
+      case NULLTYPE: return nullval;
       case CUSTOM: return nullval;
     }
     case POINTER: switch (rhs.type->kind) {
@@ -560,6 +572,7 @@ static typed_value binary_op(typed_value lhs, typed_value rhs, std::string_view 
         return binary_op(lhs, {ctx.builder.CreateLoad(t->llvm_type(loc, ctx), rhs.value), t}, op, loc, ctx);
       }
       case FUNCTION: return nullval;
+      case NULLTYPE: return nullval;
       case CUSTOM: return nullval;
     }
     case REFERENCE: {
@@ -749,11 +762,13 @@ static typed_value binary_op(typed_value lhs, typed_value rhs, std::string_view 
           break;
         case REFERENCE: break;
         case FUNCTION: return nullval;
+        case NULLTYPE: return nullval;
         case CUSTOM: break;
       }
       return binary_op({ctx.builder.CreateLoad(t->llvm_type(loc, ctx), lhs.value), t}, rhs, op, loc, ctx);
     }
     case FUNCTION: return nullval;
+    case NULLTYPE: return nullval;
     case CUSTOM: return nullval;
   }
 }
@@ -773,7 +788,7 @@ static std::string invalid_args(typed_value tv, std::vector<typed_value>&& args)
   return str;
 }
 static typed_value call(typed_value tv, std::vector<typed_value>&& args, location loc, compile_context& ctx) {
-  if (!(tv.value && tv.type)) return nullval;
+  if (!tv.type) return nullval;
   switch (tv.type->kind) {
     case INTEGER:
     case FLOAT:
@@ -798,7 +813,12 @@ static typed_value call(typed_value tv, std::vector<typed_value>&& args, locatio
       }
       return {ctx.builder.CreateCall(llvm::cast<llvm::FunctionType>(f->llvm_type(loc, ctx)), tv.value, args_v), f->ret};
     }
-    case CUSTOM: return nullval;
+    case NULLTYPE:
+      ctx.flags.onerror(loc, invalid_args(tv, std::move(args)), ERROR);
+      return nullval;
+    case CUSTOM:
+      ctx.flags.onerror(loc, invalid_args(tv, std::move(args)), ERROR);
+      return nullval;
   }
 }
 static std::string concat(std::vector<std::string_view> const& vals, std::string_view other) {
@@ -945,22 +965,21 @@ typed_value cobalt::ast::call_ast::codegen(compile_context& ctx) const {
   auto self = val(ctx);
   std::vector<typed_value> args_v(args.size());
   for (std::size_t i = 0; i < args.size(); ++i) args_v[i] = args[i](ctx);
-  return call(self, std::move(args_v), loc, ctx);
+  auto tv = call(self, std::move(args_v), loc, ctx);
+  return tv;
 }
 typed_value cobalt::ast::fndef_ast::codegen(compile_context& ctx) const {
-  std::vector<llvm::Type*> params_t;
-  std::vector<type_ptr> args_t;
-  params_t.reserve(args.size());
-  args_t.reserve(args.size());
+  std::vector<llvm::Type*> params_t(args.size());
+  std::vector<type_ptr> args_t(args.size());
   std::vector<std::string_view> old_path;
-  for (auto [_, type] : args) {
-    auto t = parse_type(type);
+  for (std::size_t i = 0; i < args.size(); ++i) {
+    auto t = parse_type(args[i].second);
     if (!t) {
-      ctx.flags.onerror(loc, (llvm::Twine("invalid type name '") + type + "' for function parameter").str(), ERROR);
+      ctx.flags.onerror(loc, (llvm::Twine("invalid type name '") + args[i].second + "' for function parameter").str(), ERROR);
       return nullval;
     }
-    args_t.push_back(t);
-    params_t.push_back(t->llvm_type(loc, ctx));
+    args_t[i] = t;
+    params_t[i] = t->llvm_type(loc, ctx);
   }
   auto t = parse_type(ret);
   if (!t) {
@@ -1035,14 +1054,14 @@ typed_value cobalt::ast::fndef_ast::codegen(compile_context& ctx) const {
     else ctx.flags.onerror(loc, "unknown annotation @" + ann, ERROR);
   }
   auto ft = llvm::FunctionType::get(t->llvm_type(loc, ctx), params_t, false);
-  auto f = llvm::Function::Create(ft, link_type, link_as.empty() ? (name.front() == '.' ? std::string_view(name) : concat(ctx.path, name)) : link_as, *ctx.module);
+  auto f = llvm::Function::Create(ft, link_type, link_as.empty() ? (name.front() == '.' ? std::string_view(name) : concat(ctx.path, name)) : link_as, *ctx.module);;
   if (!f) return nullval;
   f->setCallingConv(cconv);
   {
     std::size_t i = 0;
     for (auto& arg : f->args()) if (!args[i].first.empty()) arg.setName(args[i].first);
   }
-  ctx.vars->insert(name, typed_value{f, types::function::get(t, std::move(args_t))});
+  ctx.vars->insert(name, typed_value{f, types::function::get(t, std::vector<type_ptr>(args_t))});
   if (!is_extern) {
     if (name.front() == '.') {
       old_path = ctx.path;
@@ -1055,11 +1074,13 @@ typed_value cobalt::ast::fndef_ast::codegen(compile_context& ctx) const {
     ctx.vars = new varmap(ctx.vars);
     for (std::size_t i = 0; i < args.size(); ++i) if (!args[i].first.empty()) ctx.vars->insert(args[i].first, typed_value{f->getArg(i), args_t[i]});
     auto tv = body(ctx);
-    if (!tv.type) ctx.builder.CreateRet(llvm::Constant::getNullValue(t->llvm_type(loc, ctx)));
-    else {
-      auto p = impl_convert(tv.value, tv.type, t, loc, ctx);
-      if (!p) ctx.builder.CreateRet(llvm::Constant::getNullValue(t->llvm_type(loc, ctx)));
-      else ctx.builder.CreateRet(p);
+    if (t->kind != NULLTYPE) {
+      if (!tv.type) ctx.builder.CreateRet(llvm::Constant::getNullValue(t->llvm_type(loc, ctx)));
+      else {
+        auto p = impl_convert(tv.value, tv.type, t, loc, ctx);
+        if (!p) ctx.builder.CreateRet(llvm::Constant::getNullValue(t->llvm_type(loc, ctx)));
+        else ctx.builder.CreateRet(p);
+      }
     }
     auto vars = ctx.vars;
     ctx.vars = ctx.vars->parent;
@@ -1070,6 +1091,8 @@ typed_value cobalt::ast::fndef_ast::codegen(compile_context& ctx) const {
   }
   return nullval;
 }
+// keyvals.hpp
+typed_value cobalt::ast::null_ast::codegen(compile_context& ctx) const {return {nullptr, types::null::get()};}
 // literals.hpp
 typed_value cobalt::ast::integer_ast::codegen(compile_context& ctx) const {
   if (suffix.empty()) return {llvm::Constant::getIntegerValue(llvm::Type::getInt64Ty(*ctx.context), val), types::integer::get(0)};

--- a/src/cobalt/codegen.cpp
+++ b/src/cobalt/codegen.cpp
@@ -1119,12 +1119,7 @@ typed_value cobalt::ast::float_ast::codegen(compile_context& ctx) const {
   }
 }
 typed_value cobalt::ast::string_ast::codegen(compile_context& ctx) const {
-  std::vector<llvm::Constant*> elems;
-  elems.reserve(val.size() + 1);
-  auto i8_ty = llvm::Type::getInt8Ty(*ctx.context);
-  for (char c : val) elems.push_back(llvm::ConstantInt::get(i8_ty, c));
-  elems.push_back(llvm::ConstantInt::get(i8_ty, 0));
-  return {llvm::ConstantArray::get(llvm::ArrayType::get(i8_ty, 0), elems), types::pointer::get(types::integer::get(8))};
+  return {ctx.builder.CreateGlobalString(val, ".co.str." + llvm::Twine(ctx.init_count++)), types::pointer::get(types::integer::get(8))};
 }
 typed_value cobalt::ast::char_ast::codegen(compile_context& ctx) const {
   if (!suffix.empty()) {

--- a/src/cobalt/codegen.cpp
+++ b/src/cobalt/codegen.cpp
@@ -1269,7 +1269,7 @@ typed_value cobalt::ast::vardef_ast::codegen(compile_context& ctx) const {
     else {
       auto t = llvm::FunctionType::get(llvm::Type::getVoidTy(*ctx.context), false);
       if (!t) return nullval;
-      auto f = llvm::Function::Create(t, llvm::GlobalValue::LinkageTypes::PrivateLinkage, "global.init." + llvm::Twine(ctx.init_count++), ctx.module.get());
+      auto f = llvm::Function::Create(t, llvm::GlobalValue::LinkageTypes::PrivateLinkage, ".co.init." + llvm::Twine(ctx.init_count++), ctx.module.get());
       if (!f) return nullval;
       auto gv = new llvm::GlobalVariable(*ctx.module, val.type(ctx)->llvm_type(loc, ctx), true, llvm::GlobalValue::LinkageTypes::ExternalLinkage, nullptr, name.front() == '.' ? std::string_view(name) : std::string_view(concat(ctx.path, name)));
       if (name.front() == '.') {

--- a/src/cobalt/parser.cpp
+++ b/src/cobalt/parser.cpp
@@ -207,7 +207,7 @@ AST parse_literals(span<token> code, flags_t flags) {
   return AST::create<ast::varget_ast>(code.empty() ? location{sstring::get("<unknown>"), 0, 0} : code.front().loc, sstring::get(std::move(str)));
 }
 AST parse_groups(span<token> code, flags_t flags) {
-  if (code.empty()) return nullptr;
+  if (code.empty()) return AST::create<ast::null_ast>(nullloc);
   switch (code.front().data.front()) {
     case '(': {
       if (code.back().data.front() != ')') flags.onerror(code.front().loc, "unmatched opening parententhesis", ERROR);
@@ -256,7 +256,7 @@ AST parse_groups(span<token> code, flags_t flags) {
   }
 }
 AST parse_calls(span<token> code, flags_t flags) {
-  if (code.empty()) return AST(nullptr);
+  if (code.empty()) return AST::create<ast::null_ast>(nullloc);
   switch (code.back().data.front()) {
     case ')': {
       auto it = code.end() - 1, end = code.begin() - 1;
@@ -302,17 +302,17 @@ AST parse_calls(span<token> code, flags_t flags) {
   }
 }
 AST parse_postfix(span<token> code, flags_t flags) {
-  if (code.empty()) return AST(nullptr);
+  if (code.empty()) return AST::create<ast::null_ast>(nullloc);
   for (auto op : post_ops) if (code.back().data == op) return AST::create<ast::unop_ast>(code.back().loc, sstring::get((llvm::Twine("p") + op).str()), parse_postfix(code.subspan(0, code.size() - 1), flags));
   return parse_calls(code, flags);
 }
 AST parse_prefix(span<token> code, flags_t flags) {
-  if (code.empty()) return AST(nullptr);
+  if (code.empty()) return AST::create<ast::null_ast>(nullloc);
   for (auto op : pre_ops) if (code.front().data == op) return AST::create<ast::unop_ast>(code.front().loc, sstring::get(op), parse_prefix(code.subspan(1), flags));
   return parse_postfix(code, flags);
 }
 AST parse_ltr_infix(span<token> code, flags_t flags, binary_operator const* start) {
-  if (code.empty()) return AST(nullptr);
+  if (code.empty()) return AST::create<ast::null_ast>(nullloc);
   binary_operator const* ptr = start;
   for (++ptr; ptr != bin_ops.end() && *ptr; ++ptr);
   span<binary_operator const> ops {start, ptr};
@@ -406,7 +406,7 @@ AST parse_ltr_infix(span<token> code, flags_t flags, binary_operator const* star
   else return parse_ltr_infix(code, flags, ptr);
 }
 AST parse_rtl_infix(span<token> code, flags_t flags, binary_operator const* start) {
-  if (code.empty()) return AST(nullptr);
+  if (code.empty()) return AST::create<ast::null_ast>(nullloc);
   binary_operator const* ptr = start;
   for (++ptr; ptr != bin_ops.end() && *ptr; ++ptr);
   span<binary_operator const> ops {start, ptr};
@@ -521,7 +521,7 @@ std::pair<AST, span<token>::iterator> parse_expr(span<token> code, flags_t flags
 }
 std::pair<AST, span<token>::iterator> parse_statement(span<token> code, flags_t flags) {
 #define UNSUPPORTED(TYPE) {flags.onerror(it->loc, TYPE " definitions are not currently supported", CRITICAL); return {AST(nullptr), code.begin() + 1};}
-  if (code.empty()) return {AST{nullptr}, code.end()};
+  if (code.empty()) return {AST::create<ast::null_ast>(nullloc), code.end()};
   auto it = code.begin(), end = code.end();
   std::string_view tok = it->data;
   std::vector<std::string> annotations;

--- a/src/cobalt/parser.cpp
+++ b/src/cobalt/parser.cpp
@@ -198,6 +198,7 @@ AST parse_literals(span<token> code, flags_t flags) {
         return AST::create<ast::char_ast>(code.front().loc, std::string(tok.substr(1)), sstring::get(""));
       case '"':
         return AST::create<ast::string_ast>(code.front().loc, std::string(tok.substr(1)), sstring::get(""));
+      case 'n': if (tok == "null") return AST::create<ast::null_ast>(code.front().loc);
       default:
         return AST::create<ast::varget_ast>(code.front().loc, sstring::get(tok));
     }

--- a/src/cobalt/print-ast.cpp
+++ b/src/cobalt/print-ast.cpp
@@ -86,6 +86,10 @@ void cobalt::ast::fndef_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefi
   for (auto const& ann : annotations) os << prefix << "├── @" << ann << '\n';
   print_node(os, prefix, body, true);
 }
+// keyvals.hpp
+void cobalt::ast::null_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {
+  print_self(os, "null");
+}
 // literals.hpp
 void cobalt::ast::integer_ast::print_impl(llvm::raw_ostream& os, llvm::Twine prefix) const {
   os << "int: " << val;


### PR DESCRIPTION
Along with various other changes, this PR adds the `null` type, which has the LLVM type `void` and a size of 0.
In addition to this, the missing file issue is fixed (I forgot to add it to the last commit).