### PR TITLE
Update annotations

### DIFF
--- a/src/cobalt/codegen.cpp
+++ b/src/cobalt/codegen.cpp
@@ -1277,7 +1277,37 @@ typed_value cobalt::ast::vardef_ast::codegen(compile_context& ctx) const {
   }
   auto local = name.substr(old);
   std::vector<std::string_view> old_path;
-  if (global) {
+  std::string_view link_as = "";
+  llvm::GlobalValue::LinkageTypes link_type = llvm::GlobalValue::ExternalLinkage;
+  bool ltset = false, is_static = false;
+  for (auto const& ann : annotations) {
+    if (ann.starts_with("static(")) {
+      if (global) ctx.flags.onerror(loc, "@static annotation cannot be used on a global variable", ERROR);
+      if (ann.size() != 8) ctx.flags.onerror(loc, "@static annotation should be used without arguments", ERROR);
+      if (is_static) ctx.flags.onerror(loc, "reuse of @static annotation", ERROR);
+      is_static = true;
+    }
+    else if (ann.starts_with("linkas(")) {
+      if (!link_as.empty()) ctx.flags.onerror(loc, "reuse of @linkas annotation", ERROR);
+      link_as = std::string_view{ann.data() + 7, ann.size() - 8};
+      if (link_as.empty()) ctx.flags.onerror(loc, "@linkas must be used with arguments", ERROR);
+    }
+    else if (ann.starts_with("link(")) {
+      if (ltset) ctx.flags.onerror(loc, "reuse of @link annotation", ERROR);
+      auto lt = std::string_view{ann.data() + 5, ann.size() - 6};
+      if (lt.empty()) ctx.flags.onerror(loc, "@link must be used with arguments", ERROR);
+      ltset = true;
+      if (lt == "external" || lt == "extern") link_type = llvm::GlobalValue::ExternalLinkage;
+      else if (lt == "weak_any" || lt == "weak-any" || lt == "weak any") link_type = llvm::GlobalValue::WeakAnyLinkage;
+      else if (lt == "weak_odr" || lt == "weak-odr" || lt == "weak odr" || lt == "weak ODR") link_type = llvm::GlobalValue::WeakODRLinkage;
+      else if (lt == "internal" || lt == "intern") link_type = llvm::GlobalValue::InternalLinkage;
+      else if (lt == "private") link_type = llvm::GlobalValue::PrivateLinkage;
+      else if (lt == "weak" || lt == "extern_weak" || lt == "extern-weak" || lt == "extern weak" || lt == "external_weak" || lt == "external-weak" || lt == "external weak") link_type = llvm::GlobalValue::ExternalWeakLinkage;
+      else ctx.flags.onerror(loc, (llvm::Twine("unknown linkage type '") + lt + "'").str(), ERROR);
+    }
+    else ctx.flags.onerror(loc, "unknown annotation @" + ann, ERROR);
+  }
+  if (global || is_static) {
     if (val.is_const()) {
       if (name.front() == '.') {
         old_path = ctx.path;
@@ -1289,7 +1319,7 @@ typed_value cobalt::ast::vardef_ast::codegen(compile_context& ctx) const {
       else ctx.path.pop_back();
       if (!tv.type) return nullval;
       auto ct = tv.type->kind == INTEGER && !static_cast<types::integer const*>(tv.type)->nbits ? types::integer::get(64) : tv.type;
-      auto gv = new llvm::GlobalVariable(*ctx.module, ct->llvm_type(loc, ctx), true, llvm::GlobalValue::LinkageTypes::ExternalLinkage, llvm::cast<llvm::Constant>(tv.value), name.front() == '.' ? std::string_view(name) : std::string_view(concat(ctx.path, name)));
+      auto gv = new llvm::GlobalVariable(*ctx.module, ct->llvm_type(loc, ctx), true, link_type, llvm::cast<llvm::Constant>(tv.value), name.front() == '.' ? std::string_view(name) : std::string_view(concat(ctx.path, name)));
       auto type = types::reference::get(ct);
       vm->insert(sstring::get(local), typed_value{gv, type});
       return {gv, type};
@@ -1301,7 +1331,7 @@ typed_value cobalt::ast::vardef_ast::codegen(compile_context& ctx) const {
       if (!f) return nullval;
       auto rt = val.type(ctx);
       auto ct = rt->kind == INTEGER && !static_cast<types::integer const*>(rt)->nbits ? types::integer::get(64) : rt;
-      auto gv = new llvm::GlobalVariable(*ctx.module, ct->llvm_type(loc, ctx), true, llvm::GlobalValue::LinkageTypes::ExternalLinkage, nullptr, name.front() == '.' ? std::string_view(name) : std::string_view(concat(ctx.path, name)));
+      auto gv = new llvm::GlobalVariable(*ctx.module, ct->llvm_type(loc, ctx), true, link_type, nullptr, name.front() == '.' ? std::string_view(name) : std::string_view(concat(ctx.path, name)));
       auto bb = llvm::BasicBlock::Create(*ctx.context, "entry", f);
       ctx.builder.SetInsertPoint(bb);
       if (name.front() == '.') {
@@ -1325,6 +1355,8 @@ typed_value cobalt::ast::vardef_ast::codegen(compile_context& ctx) const {
     }
   }
   else {
+    if (ltset) ctx.flags.onerror(loc, "@link annotation can only be used on global or static variables", ERROR);
+    if (!link_as.empty()) ctx.flags.onerror(loc, "@linkas annotation can only be used on global or static variables", ERROR);
     if (name.front() == '.') {
       old_path = ctx.path;
       ctx.path = {name.substr(1)};

--- a/src/cobalt/codegen.cpp
+++ b/src/cobalt/codegen.cpp
@@ -1278,7 +1278,7 @@ typed_value cobalt::ast::vardef_ast::codegen(compile_context& ctx) const {
   auto local = name.substr(old);
   std::vector<std::string_view> old_path;
   std::string_view link_as = "";
-  llvm::GlobalValue::LinkageTypes link_type = llvm::GlobalValue::ExternalLinkage;
+  llvm::GlobalValue::LinkageTypes link_type = global ? llvm::GlobalValue::ExternalLinkage : llvm::GlobalValue::PrivateLinkage;
   bool ltset = false, is_static = false;
   for (auto const& ann : annotations) {
     if (ann.starts_with("static(")) {

--- a/src/cobalt/parser.cpp
+++ b/src/cobalt/parser.cpp
@@ -609,11 +609,12 @@ std::pair<AST, span<token>::iterator> parse_statement(span<token> code, flags_t 
 #define UNSUPPORTED(TYPE) {flags.onerror(it->loc, TYPE " definitions are not currently supported", CRITICAL); return {AST(nullptr), code.begin() + 1};}
   if (code.empty()) return {AST::create<ast::null_ast>(nullloc), code.end()};
   auto it = code.begin(), end = code.end();
-  std::string_view tok = it->data;
   std::vector<std::string> annotations;
+  ST_BEGIN:
+  std::string_view tok = it->data;
   switch (tok.front()) {
     case ';': break;
-    case '@': annotations.push_back(std::string(tok.substr(1))); break;
+    case '@': annotations.push_back(std::string(tok.substr(1))); ++it; goto ST_BEGIN;
     case 'c':
       if (tok == "cr") UNSUPPORTED("coroutine")
       else goto ST_DEFAULT;


### PR DESCRIPTION
Annotations for functions have been implemented and merged into `dev.codegen`, but since general development on code generation is done, it can now be merged directly into `main`.
Since the last merge, the `@linkas` annotation has been changed to create aliases and the `@static` and `@link` annotations have been added for variable definitions.